### PR TITLE
chore: V1.2.0 release - verified authorship and CI/CD hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,7 +406,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PostgreSQL schema-aware queries
 - MySQL foreign key check handling
 
-[Unreleased]: https://github.com/iamvirul/deepdiff-db/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/iamvirul/deepdiff-db/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/iamvirul/deepdiff-db/compare/v0.9...v1.0.0
 [0.9]: https://github.com/iamvirul/deepdiff-db/compare/v0.8...v0.9
 [0.8]: https://github.com/iamvirul/deepdiff-db/compare/v0.7...v0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - TBD
+
 ### Added
 - **GitHub OAuth author verification for `version commit`** (issue #77)
   - `version init` now prompts to authenticate via GitHub device flow; verified username stored in `.deepdiffdb/config` (`0o600` permissions, token never persisted)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.0] - TBD
+## [1.2.0] - 2026-04-05
 
 ### Added
 - **GitHub OAuth author verification for `version commit`** (issue #77)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,13 +8,13 @@ We release a new version every **Saturday**. Each release includes one or more f
 
 ---
 
-## Current Status: v1.2.0 — Verified Authorship & CI/CD Hardening
+## Current Status: v1.2.0 — Verified Authorship & CI/CD Hardening 🎉
 
-**In Development** — targeting next Saturday release.
+**Released:** 2026-04-05
 
-**Scope:**
-- GitHub OAuth author verification for `version commit` (issue #77) ✅ merged
-- Documentation & website updates for v1.2.0
+**Features:**
+- GitHub OAuth author verification for `version commit` (issue #77) ✅
+- Documentation & website updates throughout
 
 ---
 
@@ -60,7 +60,7 @@ We release a new version every **Saturday**. Each release includes one or more f
 - New `internal/version` package: `model.go`, `store.go`, `rollback.go`
 - Sample 17: Git-like Versioning — two MySQL 8 containers, three-sprint demo, automated `demo.sh`
 
-### v1.2.0: Verified Authorship & CI/CD Hardening (In Progress)
+### v1.2.0: Verified Authorship & CI/CD Hardening (Released 2026-04-05)
 
 **Scope:**
 - **GitHub OAuth author verification** (issue #77) — `version init` prompts GitHub device flow; verified `github:<username>` stored in `.deepdiffdb/config` (`0o600`); used automatically by `version commit`; `--skip-auth` for CI; `DEEPDIFFDB_GITHUB_CLIENT_ID` env var or build-time `-ldflags` injection

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ We release a new version every **Saturday**. Each release includes one or more f
 - Per-batch memory telemetry at DEBUG log level (`alloc_mb`, `batch`)
 - Oracle Database support — pure Go driver, no Instant Client required
 - Git-like versioning — `version init/commit/log/diff/rollback` with SHA-256 content-addressable commit objects and offline rollback SQL generation
-- **NEW:** GitHub OAuth author verification — device flow auth in `version init`; verified `github:<username>` used automatically in `version commit`
+- **NEW in v1.2.0:** GitHub OAuth author verification — device flow auth in `version init`; verified `github:<username>` used automatically in `version commit`
 
 ---
 
@@ -291,5 +291,5 @@ If you'd like to contribute to any of these features, please:
 
 ---
 
-**Last Updated:** 2026-03-22
+**Last Updated:** 2026-04-05
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,11 +8,21 @@ We release a new version every **Saturday**. Each release includes one or more f
 
 ---
 
-## Current Status: v1.1.0 — Git-like Versioning 🎉
+## Current Status: v1.2.0 — Verified Authorship & CI/CD Hardening
 
-**Last Release:** 2026-03-31
+**In Development** — targeting next Saturday release.
 
-**Current Features:**
+**Scope:**
+- GitHub OAuth author verification for `version commit` (issue #77) ✅ merged
+- Documentation & website updates for v1.2.0
+
+---
+
+## Previous Release: v1.1.0 — Git-like Versioning 🎉
+
+**Released:** 2026-04-01
+
+**Features:**
 - Schema drift detection and standalone schema migration (`schema-migrate`)
 - Row-level data comparison with SHA-256 hashing
 - Migration pack generation and transactional apply mode
@@ -32,7 +42,8 @@ We release a new version every **Saturday**. Each release includes one or more f
 - Bounded O(batch_size) memory during hashing regardless of table size
 - Per-batch memory telemetry at DEBUG log level (`alloc_mb`, `batch`)
 - Oracle Database support — pure Go driver, no Instant Client required
-- **NEW:** Git-like versioning — `version init/commit/log/diff/rollback` with SHA-256 content-addressable commit objects and offline rollback SQL generation
+- Git-like versioning — `version init/commit/log/diff/rollback` with SHA-256 content-addressable commit objects and offline rollback SQL generation
+- **NEW:** GitHub OAuth author verification — device flow auth in `version init`; verified `github:<username>` used automatically in `version commit`
 
 ---
 
@@ -48,6 +59,12 @@ We release a new version every **Saturday**. Each release includes one or more f
 - `version rollback <hash>` — generates driver-aware rollback SQL offline by inverting the stored diff; same safety defaults as `schema-migrate` (destructive ops commented out by default); `--out` and `--driver` flags
 - New `internal/version` package: `model.go`, `store.go`, `rollback.go`
 - Sample 17: Git-like Versioning — two MySQL 8 containers, three-sprint demo, automated `demo.sh`
+
+### v1.2.0: Verified Authorship & CI/CD Hardening (In Progress)
+
+**Scope:**
+- **GitHub OAuth author verification** (issue #77) — `version init` prompts GitHub device flow; verified `github:<username>` stored in `.deepdiffdb/config` (`0o600`); used automatically by `version commit`; `--skip-auth` for CI; `DEEPDIFFDB_GITHUB_CLIENT_ID` env var or build-time `-ldflags` injection
+- Documentation and website updated throughout for v1.2.0
 
 ### v0.6: Enhanced Error Handling & Logging (Released 2026-01-06)
 
@@ -190,31 +207,25 @@ We release a new version every **Saturday**. Each release includes one or more f
    - ~~`version branch` / `version checkout` / `version tree`~~ — branching and ASCII graph
    - See [Sample 17](https://github.com/iamvirul/deepdiff-db/tree/main/samples/17-git-like-versioning) for end-to-end demo
 
-2. **GitHub OAuth Author Verification** ✅ **Done (issue #77)**
+2. ~~**GitHub OAuth Author Verification**~~ ✅ **Shipping in v1.2.0 (issue #77)**
    - ~~`version init` GitHub device flow authentication~~
    - ~~`version commit` reads verified `github:<username>` from `.deepdiffdb/config`~~
    - ~~Build-time client ID injection via `-ldflags` in `release.yml`~~
    - ~~`DEEPDIFFDB_GITHUB_CLIENT_ID` env var override for local use~~
 
-3. **CI/CD Integration**
-   - GitHub Actions plugin
-   - GitLab CI integration
-   - Jenkins plugin
-   - Pre-commit hooks
-
-3. **Advanced Schema Features**
+3. **Advanced Schema Features** _(v1.3.0 candidate)_
    - View and stored procedure diff
    - Trigger comparison
    - Function/procedure diff
    - Sequence comparison
 
-4. **Performance & Scalability**
+4. **Performance & Scalability** _(v1.4.0 candidate)_
    - Parallel table processing
    - Distributed diff processing
    - Incremental diff (only changed tables)
    - Diff caching
 
-5. **Developer Experience**
+5. **Developer Experience** _(v1.5.0 candidate)_
    - VS Code extension
    - CLI autocomplete
    - Configuration wizard

--- a/website/docs/deployment/cicd.md
+++ b/website/docs/deployment/cicd.md
@@ -144,7 +144,7 @@ jobs:
 
 ## Tips
 
-- **Pin the version** in CI with `DEEPDIFFDB_VERSION: v1.1.0` to avoid unexpected upgrades.
+- **Pin the version** in CI with `DEEPDIFFDB_VERSION: v1.2.0` to avoid unexpected upgrades.
 - **Cache the binary** between runs using your CI platform's cache action.
 - **Fail fast on schema changes** — set `--exit-code` (coming in a future release) to fail CI if any drift is detected.
 - **Use Docker** in CI for a hermetic environment: `docker run ghcr.io/iamvirul/deepdiff-db:latest diff`.

--- a/website/docs/deployment/docker.md
+++ b/website/docs/deployment/docker.md
@@ -13,7 +13,7 @@ DeepDiff DB ships a minimal, scratch-based Docker image with zero native depende
 docker pull ghcr.io/iamvirul/deepdiff-db:latest
 
 # Specific version
-docker pull ghcr.io/iamvirul/deepdiff-db:v1.1.0
+docker pull ghcr.io/iamvirul/deepdiff-db:v1.2.0
 ```
 
 ## Run a diff
@@ -52,8 +52,8 @@ Copy and adapt `docker-compose.example.yml` to point at your real databases.
 
 ```bash
 docker build \
-  --build-arg VERSION=v1.1.0 \
-  -t deepdiff-db:v1.1.0 \
+  --build-arg VERSION=v1.2.0 \
+  -t deepdiff-db:v1.2.0 \
   .
 ```
 
@@ -70,8 +70,8 @@ The multi-stage build compiles a statically linked binary with `CGO_ENABLED=0`, 
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `v1.1.0` | Specific version |
-| `v1.1.0-amd64` | Architecture-specific manifest |
-| `v1.1.0-arm64` | Architecture-specific manifest |
+| `v1.2.0` | Specific version |
+| `v1.2.0-amd64` | Architecture-specific manifest |
+| `v1.2.0-arm64` | Architecture-specific manifest |
 
 Multi-arch manifests cover `linux/amd64` and `linux/arm64`.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -148,7 +148,7 @@ deepdiffdb --version
 Expected output:
 
 ```
-DeepDiff DB v1.1.0
+DeepDiff DB v1.2.0
 ```
 
 ---

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
         { type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs' },
         { to: '/blog', label: 'Blog', position: 'left' },
         { href: 'https://github.com/iamvirul/deepdiff-db', label: 'GitHub', position: 'right' },
-        { href: 'https://github.com/iamvirul/deepdiff-db/releases', label: 'v1.1', position: 'right' },
+        { href: 'https://github.com/iamvirul/deepdiff-db/releases', label: 'v1.2', position: 'right' },
       ],
     },
     footer: {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -131,7 +131,7 @@ export default function Home() {
       <div className={styles.hero}>
         <div className={styles.heroBg} />
         <div className={styles.heroContent}>
-          <div className={styles.heroBadge}>v1.1 — Production ready release</div>
+          <div className={styles.heroBadge}>v1.2 — Verified authorship & CI/CD hardening</div>
           <h1 className={styles.heroTitle}>
             Database diff that<br />
             <span className={styles.heroGradient}>actually ships</span>


### PR DESCRIPTION
## Summary

- Promotes the GitHub OAuth author verification feature (merged via PR #78) into the `[1.2.0] - 2026-04-05` CHANGELOG entry
- Updates ROADMAP: current status banner → v1.2.0 🎉, completed releases entry added, Phase 2 list updated with candidate versions for future milestones
- Bumps all version pins across the website (`v1.1.0` → `v1.2.0`): installation guide, Docker docs, CI/CD tips
- Updates navbar badge (`v1.1` → `v1.2`) and homepage hero badge
- No code changes — documentation and release metadata only

## Test plan

- [x] Verify CHANGELOG `[1.2.0]` entry is present with correct date
- [x] Verify ROADMAP current status shows v1.2.0 🎉 with release date
- [x] Verify website navbar shows `v1.2`
- [x] Verify homepage hero badge reflects v1.2
- [x] Merge and tag `v1.2.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub OAuth author verification integrated into version management
  * `version init` now prompts for GitHub authentication (skippable with `--skip-auth` for CI/CD environments)
  * `version commit` automatically sets verified author information when available

* **Documentation**
  * Updated version references from v1.1.0 to v1.2.0 across all documentation and website
  * Updated release notes and roadmap to reflect new features and upcoming phases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->