### PR TITLE
feat: CI/CD Integration — schema-diff --quiet/--output-dir, Jenkins, pre-commit hooks (issue #17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.24', '1.25.8']
+        go-version: ['1.24', '1.25.9']
     
     steps:
       - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
         continue-on-error: false
 
       - name: Merge coverage files
-        if: matrix.go-version == '1.25.8'
+        if: matrix.go-version == '1.25.9'
         run: |
           # Merge coverage files using go tool cover
           echo "mode: atomic" > coverage.txt
@@ -49,7 +49,7 @@ jobs:
         continue-on-error: false
 
       - name: Verify coverage file exists
-        if: matrix.go-version == '1.25.8'
+        if: matrix.go-version == '1.25.9'
         run: |
           if [ ! -f coverage.txt ]; then
             echo "Error: coverage.txt not found"
@@ -59,7 +59,7 @@ jobs:
           head -5 coverage.txt
 
       - name: Upload coverage artifact for merging
-        if: matrix.go-version == '1.25.8'
+        if: matrix.go-version == '1.25.9'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-unit-${{ github.run_id }}
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Verify dependencies
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Download unit test coverage artifact
@@ -173,7 +173,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Run linter
@@ -195,7 +195,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Download dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,105 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '21 15 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: go
+          build-mode: autobuild
+        - language: javascript-typescript
+          build-mode: none
+        - language: ruby
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.9'
           cache-dependency-path: go.sum
 
       - name: Run gosec

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,27 @@
+# DeepDiff DB — official pre-commit hooks definition.
+#
+# To use these hooks, add the following to your .pre-commit-config.yaml:
+#
+#   repos:
+#     - repo: https://github.com/iamvirul/deepdiff-db
+#       rev: v0.9.0   # pin to a release tag
+#       hooks:
+#         - id: deepdiff-db-schema
+#           # Optional: override the config path
+#           # args: [--config, path/to/deepdiffdb.config.yaml]
+#
+# Environment variables:
+#   DEEPDIFFDB_CONFIG      Path to config file (default: deepdiffdb.config.yaml)
+#   DEEPDIFFDB_ALLOW_DRIFT Set to "1" to warn instead of blocking on schema drift
+
+- id: deepdiff-db-schema
+  name: DeepDiff DB — schema drift check
+  language: script
+  entry: examples/cicd/pre-commit-hook.sh
+  pass_filenames: false
+  always_run: false
+  files: \.(sql|go|py|rb|java|ts|js)$
+  description: >
+    Runs deepdiffdb schema-diff before every commit. Blocks the commit if
+    unexpected schema drift is detected between your production and development
+    databases. Set DEEPDIFFDB_ALLOW_DRIFT=1 to warn instead of block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `examples/cicd/github-actions.yml` — removed reference to non-existent `--output-format json` flag; updated to read `schema_diff.json` and `content_diff.json` written to disk, with correct `jq` queries matching the actual JSON structure (`[.tables[] | select(.has_differences == true)] | length`).
 - `examples/cicd/gitlab-ci.yml` — same fix: `result.json` reference replaced with `schema_diff.json` and corrected `jq` query.
 
+### Security
+- Upgraded Go from **1.25.8 → 1.25.9** to resolve four stdlib CVEs: GO-2026-4947 and GO-2026-4946 (`crypto/x509` chain building / policy validation), GO-2026-4870 (`crypto/tls` TLS 1.3 KeyUpdate DoS), GO-2026-4865 (`html/template` XSS via JsBraceDepth).
+
 ## [1.2.0] - 2026-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-19
+
+### Added
+- **CI/CD Integration** (issue #17)
+  - `schema-diff --quiet` flag: suppresses progress bars, metrics summary, and informational stdout output; automatically raises the effective log level from `info` → `warn` so pipelines are silent on success without extra flags. Explicit `--log-level debug` still overrides when set.
+  - `schema-diff --output-dir <path>` flag: overrides `output.dir` from config at runtime, enabling pre-commit hooks and CI steps to redirect reports to a temporary directory without touching the config file.
+  - `.pre-commit-hooks.yaml` in the repo root — official [pre-commit framework](https://pre-commit.com/) hooks definition; users can now reference the repo directly in `.pre-commit-config.yaml` instead of copying the shell script manually.
+  - `examples/cicd/Jenkinsfile` — Declarative Pipeline covering install, masked-credential config write, schema-diff, data diff, result evaluation, and artifact archiving; marks build `UNSTABLE` on drift rather than `FAILED` so downstream stages still run.
+
+### Fixed
+- `examples/cicd/github-actions.yml` — removed reference to non-existent `--output-format json` flag; updated to read `schema_diff.json` and `content_diff.json` written to disk, with correct `jq` queries matching the actual JSON structure (`[.tables[] | select(.has_differences == true)] | length`).
+- `examples/cicd/gitlab-ci.yml` — same fix: `result.json` reference replaced with `schema_diff.json` and corrected `jq` query.
+
 ## [1.2.0] - 2026-04-05
 
 ### Added
@@ -406,7 +419,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PostgreSQL schema-aware queries
 - MySQL foreign key check handling
 
-[Unreleased]: https://github.com/iamvirul/deepdiff-db/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/iamvirul/deepdiff-db/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/iamvirul/deepdiff-db/compare/v0.9...v1.0.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,20 @@ We release a new version every **Saturday**. Each release includes one or more f
 
 ---
 
-## Current Status: v1.2.0 — Verified Authorship & CI/CD Hardening 🎉
+## Current Status: v1.3.0 — CI/CD Integration 🎉
+
+**Released:** 2026-04-19
+
+**Features:**
+- `schema-diff --quiet` and `--output-dir` flags for CI/pre-commit use (issue #17) ✅
+- Official `.pre-commit-hooks.yaml` for the pre-commit framework ✅
+- Jenkins Declarative Pipeline example ✅
+- Fixed CI/CD example files to use correct JSON output structure ✅
+- Documentation updated across commands, deployment guide, changelog, and roadmap ✅
+
+---
+
+## Previous Release: v1.2.0 — Verified Authorship & CI/CD Hardening 🎉
 
 **Released:** 2026-04-05
 
@@ -18,7 +31,7 @@ We release a new version every **Saturday**. Each release includes one or more f
 
 ---
 
-## Previous Release: v1.1.0 — Git-like Versioning 🎉
+## Earlier Release: v1.1.0 — Git-like Versioning 🎉
 
 **Released:** 2026-04-01
 
@@ -59,6 +72,15 @@ We release a new version every **Saturday**. Each release includes one or more f
 - `version rollback <hash>` — generates driver-aware rollback SQL offline by inverting the stored diff; same safety defaults as `schema-migrate` (destructive ops commented out by default); `--out` and `--driver` flags
 - New `internal/version` package: `model.go`, `store.go`, `rollback.go`
 - Sample 17: Git-like Versioning — two MySQL 8 containers, three-sprint demo, automated `demo.sh`
+
+### v1.3.0: CI/CD Integration (Released 2026-04-19)
+
+**Features Delivered:**
+- `schema-diff --quiet`: suppresses all progress/informational output; automatically raises effective log level to `warn`; explicit `--log-level debug` overrides
+- `schema-diff --output-dir <path>`: overrides `output.dir` at runtime without editing the config file — essential for pre-commit hooks using temp dirs
+- `.pre-commit-hooks.yaml`: official pre-commit framework hooks definition at repo root; users reference the repo directly instead of copying the shell script
+- `examples/cicd/Jenkinsfile`: Declarative Pipeline with masked credential injection, schema-diff, data diff, result evaluation (UNSTABLE on drift), and artifact archiving
+- Fixed `examples/cicd/github-actions.yml` and `gitlab-ci.yml`: removed references to non-existent `--output-format json` flag; updated `jq` queries to match actual JSON structure
 
 ### v1.2.0: Verified Authorship & CI/CD Hardening (Released 2026-04-05)
 
@@ -213,7 +235,14 @@ We release a new version every **Saturday**. Each release includes one or more f
    - ~~Build-time client ID injection via `-ldflags` in `release.yml`~~
    - ~~`DEEPDIFFDB_GITHUB_CLIENT_ID` env var override for local use~~
 
-3. **Advanced Schema Features** _(v1.3.0 candidate)_
+3. ~~**CI/CD Integration**~~ ✅ **Released in v1.3.0 (issue #17)**
+   - ~~`schema-diff --quiet` for silent CI checks~~
+   - ~~`schema-diff --output-dir` for temp dir output~~
+   - ~~Official `.pre-commit-hooks.yaml`~~
+   - ~~Jenkins Declarative Pipeline example~~
+   - ~~Fixed GitHub Actions and GitLab CI example files~~
+
+4. **Advanced Schema Features** _(v1.4.0 candidate)_
    - View and stored procedure diff
    - Trigger comparison
    - Function/procedure diff

--- a/cmd/deepdiffdb/main.go
+++ b/cmd/deepdiffdb/main.go
@@ -1202,6 +1202,8 @@ func countDecisionResolutions(resolutions []resolve.Resolution, decision resolve
 func runSchemaDiff(args []string) error {
 	fs := flag.NewFlagSet("schema-diff", flag.ContinueOnError)
 	configPath := fs.String("config", "deepdiffdb.config.yaml", "Path to configuration file")
+	outputDir := fs.String("output-dir", "", "Override output directory from config (useful for temp dirs in CI/pre-commit hooks)")
+	quiet := fs.Bool("quiet", false, "Suppress progress bars and informational output (for CI/pre-commit use)")
 	verbose := fs.Bool("verbose", false, "Enable verbose logging")
 	logFile := fs.String("log-file", "", "Write logs to file")
 	logLevel := fs.String("log-level", "info", "Log level: debug, info, warn, error")
@@ -1210,8 +1212,16 @@ func runSchemaDiff(args []string) error {
 		return err
 	}
 
+	// --quiet suppresses INFO-level log lines unless the caller explicitly requested
+	// a more verbose level (debug). This makes the tool fully silent on success when
+	// used in pre-commit hooks or CI pipelines that control their own UX.
+	effectiveLogLevel := *logLevel
+	if *quiet && effectiveLogLevel == "info" {
+		effectiveLogLevel = "warn"
+	}
+
 	// Initialize logger
-	log, logCloser, err := initializeLogger(*verbose, *logFile, *logLevel, *logFormat)
+	log, logCloser, err := initializeLogger(*verbose, *logFile, effectiveLogLevel, *logFormat)
 	if err != nil {
 		return err
 	}
@@ -1221,18 +1231,20 @@ func runSchemaDiff(args []string) error {
 
 	log.Info("starting schema diff")
 
-	// Initialize progress manager (disabled in verbose mode to avoid conflicts)
+	// Initialize progress manager; disabled in verbose or quiet mode to avoid interleaved output.
 	progressMgr := progress.NewManager(progress.Config{
-		Enabled:     !*verbose,
-		ShowMetrics: true,
+		Enabled:     !*verbose && !*quiet,
+		ShowMetrics: !*quiet,
 	})
 	defer func() {
 		progressMgr.Finish()
-		// Print metrics summary if available
-		if metrics := progressMgr.GetMetrics(); metrics != nil {
-			summary := metrics.Summary()
-			if summary != "" {
-				fmt.Println(summary)
+		// Print metrics summary unless quiet mode suppresses UI output.
+		if !*quiet {
+			if metrics := progressMgr.GetMetrics(); metrics != nil {
+				summary := metrics.Summary()
+				if summary != "" {
+					fmt.Println(summary)
+				}
 			}
 		}
 	}()
@@ -1240,6 +1252,12 @@ func runSchemaDiff(args []string) error {
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// --output-dir overrides the directory from config, allowing callers such as
+	// pre-commit hooks to redirect output to a temporary directory.
+	if *outputDir != "" {
+		cfg.Output.Dir = *outputDir
 	}
 
 	log.Debug("configuration loaded", "config_path", *configPath)
@@ -1283,7 +1301,9 @@ func runSchemaDiff(args []string) error {
 	}
 
 	log.Info("schema diff complete - no drift detected")
-	fmt.Println("Schema match confirmed. No drift detected.")
+	if !*quiet {
+		fmt.Println("Schema match confirmed. No drift detected.")
+	}
 	return nil
 }
 

--- a/examples/cicd/Jenkinsfile
+++ b/examples/cicd/Jenkinsfile
@@ -1,0 +1,166 @@
+// DeepDiff DB — Jenkins Declarative Pipeline Example
+//
+// This pipeline runs a schema and data diff on every pull request.
+// It archives the diff reports as build artifacts and marks the build
+// unstable (rather than failed) when schema drift is detected so that
+// downstream stages can still run.
+//
+// Prerequisites:
+//   1. Create Jenkins credentials (Manage Jenkins → Credentials):
+//        PROD_DB_HOST, PROD_DB_PORT, PROD_DB_USER, PROD_DB_PASSWORD, PROD_DB_NAME
+//        DEV_DB_HOST,  DEV_DB_PORT,  DEV_DB_USER,  DEV_DB_PASSWORD,  DEV_DB_NAME
+//   2. Set DEEPDIFFDB_VERSION in Jenkins → Manage Jenkins → System → Global properties
+//      (environment variable), or pin it here.
+//   3. Ensure the agent has curl, tar, and jq available (or use the Docker agent below).
+
+pipeline {
+    agent {
+        // Option A: run on any agent that has curl + jq installed.
+        label 'linux'
+
+        // Option B: use the official Docker image (no tool installation needed).
+        // Uncomment the block below and comment out the `label` line above.
+        //
+        // docker {
+        //     image 'ghcr.io/iamvirul/deepdiff-db:latest'
+        //     args  '--entrypoint='
+        // }
+    }
+
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '20'))
+    }
+
+    environment {
+        DEEPDIFFDB_VERSION = "${env.DEEPDIFFDB_VERSION ?: 'latest'}"
+        OUTPUT_DIR         = 'diff-output'
+    }
+
+    stages {
+        stage('Install DeepDiff DB') {
+            // Skip this stage when using the Docker agent (tool is already on PATH).
+            when { not { environment name: 'DEEPDIFFDB_SKIP_INSTALL', value: 'true' } }
+            steps {
+                sh '''
+                    set -euo pipefail
+                    VERSION="${DEEPDIFFDB_VERSION}"
+                    if [ "${VERSION}" = "latest" ]; then
+                        VERSION=$(curl -fsSL https://api.github.com/repos/iamvirul/deepdiff-db/releases/latest \
+                            | grep '"tag_name"' | cut -d'"' -f4)
+                    fi
+                    curl -fsSL \
+                        "https://github.com/iamvirul/deepdiff-db/releases/download/${VERSION}/deepdiffdb_${VERSION}_linux_amd64.tar.gz" \
+                        | tar -xz deepdiffdb
+                    chmod +x deepdiffdb
+                    mv deepdiffdb /usr/local/bin/deepdiffdb
+                    deepdiffdb --version
+                '''
+            }
+        }
+
+        stage('Write Config') {
+            steps {
+                withCredentials([
+                    string(credentialsId: 'PROD_DB_HOST',     variable: 'PROD_HOST'),
+                    string(credentialsId: 'PROD_DB_PORT',     variable: 'PROD_PORT'),
+                    string(credentialsId: 'PROD_DB_USER',     variable: 'PROD_USER'),
+                    string(credentialsId: 'PROD_DB_PASSWORD', variable: 'PROD_PASS'),
+                    string(credentialsId: 'PROD_DB_NAME',     variable: 'PROD_NAME'),
+                    string(credentialsId: 'DEV_DB_HOST',      variable: 'DEV_HOST'),
+                    string(credentialsId: 'DEV_DB_PORT',      variable: 'DEV_PORT'),
+                    string(credentialsId: 'DEV_DB_USER',      variable: 'DEV_USER'),
+                    string(credentialsId: 'DEV_DB_PASSWORD',  variable: 'DEV_PASS'),
+                    string(credentialsId: 'DEV_DB_NAME',      variable: 'DEV_NAME'),
+                ]) {
+                    // Write config to disk. Credentials are injected via env vars and
+                    // never logged (Jenkins masks them automatically).
+                    sh '''
+                        mkdir -p "${OUTPUT_DIR}"
+                        cat > deepdiffdb.config.yaml <<EOF
+production:
+  driver: mysql
+  host: "${PROD_HOST}"
+  port: ${PROD_PORT}
+  user: "${PROD_USER}"
+  password: "${PROD_PASS}"
+  database: "${PROD_NAME}"
+development:
+  driver: mysql
+  host: "${DEV_HOST}"
+  port: ${DEV_PORT}
+  user: "${DEV_USER}"
+  password: "${DEV_PASS}"
+  database: "${DEV_NAME}"
+output:
+  dir: "${OUTPUT_DIR}"
+EOF
+                    '''
+                }
+            }
+        }
+
+        stage('Schema Diff') {
+            steps {
+                // Exit code 0 = no drift. Non-zero = drift detected or tool error.
+                // `|| true` lets the pipeline continue; the post section marks the
+                // build unstable based on the report content.
+                sh 'deepdiffdb schema-diff --config deepdiffdb.config.yaml || true'
+            }
+        }
+
+        stage('Data Diff') {
+            steps {
+                sh 'deepdiffdb diff --config deepdiffdb.config.yaml || true'
+            }
+        }
+
+        stage('Evaluate Results') {
+            steps {
+                script {
+                    def schemaDriftFile = "${OUTPUT_DIR}/schema_diff.json"
+                    if (fileExists(schemaDriftFile)) {
+                        def driftCount = sh(
+                            script: "jq '[.tables[] | select(.has_differences == true)] | length' ${schemaDriftFile}",
+                            returnStdout: true
+                        ).trim().toInteger()
+
+                        if (driftCount > 0) {
+                            echo "WARNING: ${driftCount} table(s) have schema drift."
+                            // Mark unstable rather than failed — downstream stages still run.
+                            currentBuild.result = 'UNSTABLE'
+                        } else {
+                            echo 'Schema: OK (no drift detected)'
+                        }
+                    }
+
+                    def summaryFile = "${OUTPUT_DIR}/summary.txt"
+                    if (fileExists(summaryFile)) {
+                        echo "=== Diff Summary ===\n${readFile(summaryFile)}"
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts(
+                artifacts: "${OUTPUT_DIR}/**",
+                allowEmptyArchive: true,
+                fingerprint: true
+            )
+            // Clean up the generated config — it contains credentials placeholders
+            // that should not persist between runs.
+            sh 'rm -f deepdiffdb.config.yaml'
+        }
+
+        unstable {
+            echo 'Build is UNSTABLE: schema drift or data changes detected. Review the archived diff-output artifacts.'
+        }
+
+        failure {
+            echo 'Build FAILED: check the console log for deepdiffdb errors.'
+        }
+    }
+}

--- a/examples/cicd/github-actions.yml
+++ b/examples/cicd/github-actions.yml
@@ -108,11 +108,15 @@ jobs:
       - name: Run diff
         id: diff
         run: |
-          deepdiffdb diff --config deepdiffdb.config.yaml \
-            --output-format json > diff-output/result.json 2>&1 || true
-          # Capture summary for PR comment
-          TABLES_CHANGED=$(jq '.schema_changes | length' diff-output/result.json 2>/dev/null || echo 0)
-          DATA_CHANGES=$(jq '.data_changes | length' diff-output/result.json 2>/dev/null || echo 0)
+          mkdir -p diff-output
+          deepdiffdb diff --config deepdiffdb.config.yaml || true
+          # Parse the JSON reports written to diff-output/ by the tool.
+          # schema_diff.json: tables[] with has_differences=true → schema changes.
+          # content_diff.json: tables[] entries are only present when rows differ.
+          TABLES_CHANGED=$(jq '[.tables[] | select(.has_differences == true)] | length' \
+            diff-output/schema_diff.json 2>/dev/null || echo 0)
+          DATA_CHANGES=$(jq '.tables | length' \
+            diff-output/content_diff.json 2>/dev/null || echo 0)
           echo "tables_changed=$TABLES_CHANGED" >> $GITHUB_OUTPUT
           echo "data_changes=$DATA_CHANGES" >> $GITHUB_OUTPUT
 
@@ -130,10 +134,10 @@ jobs:
               `| Schema changes | ${tablesChanged} |`,
               `| Tables with data changes | ${dataChanges} |`,
               '',
-              '<details><summary>Full diff output</summary>',
+              '<details><summary>Full schema diff</summary>',
               '',
               '```',
-              require("fs").readFileSync("diff-output/result.json", "utf8").slice(0, 4000),
+              require("fs").readFileSync("diff-output/schema_diff.txt", "utf8").slice(0, 4000),
               '```',
               '</details>',
             ].join('\n');

--- a/examples/cicd/gitlab-ci.yml
+++ b/examples/cicd/gitlab-ci.yml
@@ -70,8 +70,8 @@ db-diff:
   after_script:
     - |
       # Post diff summary as MR note via GitLab API
-      if [ -f diff-output/result.json ]; then
-        TABLES=$(jq '.schema_changes | length' diff-output/result.json 2>/dev/null || echo 0)
+      if [ -f diff-output/schema_diff.json ]; then
+        TABLES=$(jq '[.tables[] | select(.has_differences == true)] | length' diff-output/schema_diff.json 2>/dev/null || echo 0)
         NOTE="**DeepDiff DB Report**\n\nSchema changes: ${TABLES}\n\nSee artifacts for full output."
         curl -s --request POST \
           --header "PRIVATE-TOKEN: ${GITLAB_API_TOKEN}" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iamvirul/deepdiff-db
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-sql-driver/mysql v1.9.3

--- a/website/docs/commands/schema-diff.md
+++ b/website/docs/commands/schema-diff.md
@@ -29,6 +29,8 @@ Tables listed in `ignore.tables` are excluded entirely.
 | Flag | Description |
 |---|---|
 | `--config` | Path to the configuration file (default: `deepdiffdb.config.yaml`) |
+| `--output-dir` | Override `output.dir` from config at runtime (e.g. point to a temp dir in CI or pre-commit hooks) |
+| `--quiet` | Suppress progress bars, metrics summary, and informational output. Automatically raises log level to `warn` so the tool is fully silent on success. Explicit `--log-level debug` overrides this. |
 | `--verbose` | Enable debug-level logging |
 | `--log-level` | Minimum log level: `debug`, `info`, `warn`, `error` (default: `info`) |
 | `--log-format` | Log output format: `text` or `json` (default: `text`) |
@@ -43,10 +45,19 @@ Both files are written to `output.dir` (default: `./diff-output`).
 | `schema_diff.json` | Machine-readable schema differences, suitable for programmatic processing or CI checks |
 | `schema_diff.txt` | Human-readable schema diff report |
 
-## Example
+## Examples
 
 ```bash
+# Standard usage
 deepdiffdb schema-diff --config deepdiffdb.config.yaml --log-level warn
+
+# CI / pre-commit: fully silent on success, non-zero exit on drift
+deepdiffdb schema-diff --config deepdiffdb.config.yaml --quiet
+
+# Redirect output to a temp dir (pre-commit hooks, ephemeral CI runners)
+deepdiffdb schema-diff --config deepdiffdb.config.yaml \
+  --output-dir /tmp/deepdiff-$$ \
+  --quiet
 ```
 
 Example `schema_diff.txt` output:

--- a/website/docs/deployment/cicd.md
+++ b/website/docs/deployment/cicd.md
@@ -4,11 +4,11 @@ sidebar_position: 2
 
 # CI/CD Integration
 
-DeepDiff DB is designed to run inside CI pipelines. Example workflows for GitHub Actions and GitLab CI are provided in [`examples/cicd/`](https://github.com/iamvirul/deepdiff-db/tree/main/examples/cicd).
+DeepDiff DB is designed to run inside CI pipelines. Ready-to-use examples for GitHub Actions, GitLab CI, Jenkins, and pre-commit hooks are in [`examples/cicd/`](https://github.com/iamvirul/deepdiff-db/tree/main/examples/cicd).
 
 ## GitHub Actions
 
-The example workflow (`.github/workflows/db-diff.yml`) runs on every pull request that touches migration files, spins up two MySQL containers, runs a diff, and posts the result as a PR comment.
+The example workflow runs on every pull request that touches migration files, spins up two MySQL containers, runs a full diff, and posts the result as a PR comment.
 
 ```yaml
 name: Database Diff Check
@@ -45,7 +45,16 @@ jobs:
           sudo mv deepdiffdb /usr/local/bin/deepdiffdb
 
       - name: Run diff
-        run: deepdiffdb diff --config deepdiffdb.config.yaml
+        run: |
+          mkdir -p diff-output
+          deepdiffdb diff --config deepdiffdb.config.yaml || true
+          # Parse the JSON reports written to diff-output/ by the tool
+          TABLES_CHANGED=$(jq '[.tables[] | select(.has_differences == true)] | length' \
+            diff-output/schema_diff.json 2>/dev/null || echo 0)
+          DATA_CHANGES=$(jq '.tables | length' \
+            diff-output/content_diff.json 2>/dev/null || echo 0)
+          echo "tables_changed=$TABLES_CHANGED" >> $GITHUB_OUTPUT
+          echo "data_changes=$DATA_CHANGES"     >> $GITHUB_OUTPUT
 ```
 
 See [`examples/cicd/github-actions.yml`](https://github.com/iamvirul/deepdiff-db/blob/main/examples/cicd/github-actions.yml) for the full example including PR comment posting and artifact upload.
@@ -59,11 +68,26 @@ db-diff:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
   script:
-    - apk add --no-cache curl tar
+    - apk add --no-cache curl tar jq
     - |
-      curl -fsSL "https://github.com/iamvirul/deepdiff-db/releases/latest/download/deepdiffdb_linux_amd64.tar.gz" \
+      VERSION=$(curl -fsSL https://api.github.com/repos/iamvirul/deepdiff-db/releases/latest \
+        | jq -r '.tag_name')
+      curl -fsSL \
+        "https://github.com/iamvirul/deepdiff-db/releases/download/${VERSION}/deepdiffdb_${VERSION}_linux_amd64.tar.gz" \
         | tar -xz deepdiffdb && mv deepdiffdb /usr/local/bin/
-    - deepdiffdb diff --config deepdiffdb.config.yaml
+    - deepdiffdb diff --config deepdiffdb.config.yaml || true
+  after_script:
+    - |
+      if [ -f diff-output/schema_diff.json ]; then
+        TABLES=$(jq '[.tables[] | select(.has_differences == true)] | length' \
+          diff-output/schema_diff.json 2>/dev/null || echo 0)
+        NOTE="**DeepDiff DB Report**\n\nSchema changes: ${TABLES}\n\nSee artifacts for full output."
+        curl -s --request POST \
+          --header "PRIVATE-TOKEN: ${GITLAB_API_TOKEN}" \
+          --data-urlencode "body=${NOTE}" \
+          "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/merge_requests/${CI_MERGE_REQUEST_IID}/notes" \
+          > /dev/null || true
+      fi
   artifacts:
     paths: [diff-output/]
     expire_in: 7 days
@@ -71,41 +95,88 @@ db-diff:
 
 See [`examples/cicd/gitlab-ci.yml`](https://github.com/iamvirul/deepdiff-db/blob/main/examples/cicd/gitlab-ci.yml) for the full example.
 
+## Jenkins
+
+The `Jenkinsfile` example uses a Declarative Pipeline with masked credentials. It marks the build `UNSTABLE` (rather than `FAILED`) on drift, so downstream stages can still run.
+
+```groovy
+pipeline {
+    agent { label 'linux' }
+
+    stages {
+        stage('Schema Diff') {
+            steps {
+                sh 'deepdiffdb schema-diff --config deepdiffdb.config.yaml || true'
+            }
+        }
+
+        stage('Data Diff') {
+            steps {
+                sh 'deepdiffdb diff --config deepdiffdb.config.yaml || true'
+            }
+        }
+
+        stage('Evaluate Results') {
+            steps {
+                script {
+                    def driftCount = sh(
+                        script: "jq '[.tables[] | select(.has_differences == true)] | length' diff-output/schema_diff.json",
+                        returnStdout: true
+                    ).trim().toInteger()
+
+                    if (driftCount > 0) {
+                        currentBuild.result = 'UNSTABLE'
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts artifacts: 'diff-output/**', allowEmptyArchive: true
+        }
+    }
+}
+```
+
+See [`examples/cicd/Jenkinsfile`](https://github.com/iamvirul/deepdiff-db/blob/main/examples/cicd/Jenkinsfile) for the full example including credential injection and install step.
+
 ## Pre-commit hook
 
-Block commits when unexpected schema drift is detected:
+Block commits when unexpected schema drift is detected.
+
+### Manual install
 
 ```bash
-# Install
 cp examples/cicd/pre-commit-hook.sh .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
-The hook runs `deepdiffdb schema-diff` and blocks the commit if drift is found. Set `DEEPDIFFDB_ALLOW_DRIFT=1` to demote it to a warning.
+The hook calls `schema-diff --quiet --output-dir <tmpdir>` so it is fully silent on success and prints a clear block message only when drift is found. Set `DEEPDIFFDB_ALLOW_DRIFT=1` to demote the block to a warning.
 
-### With pre-commit framework
+### With the pre-commit framework
 
-Add to `.pre-commit-config.yaml`:
+DeepDiff DB ships a `.pre-commit-hooks.yaml` at the repo root, so you can reference it directly from `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-  - repo: local
+  - repo: https://github.com/iamvirul/deepdiff-db
+    rev: v1.3.0   # pin to a release tag
     hooks:
-      - id: deepdiff-db
-        name: DeepDiff DB schema check
-        entry: examples/cicd/pre-commit-hook.sh
-        language: script
-        pass_filenames: false
+      - id: deepdiff-db-schema
+        # Optional: override the config path
+        # args: [--config, path/to/deepdiffdb.config.yaml]
 ```
+
+The hook triggers on `.sql`, `.go`, `.py`, `.ts`, `.js`, `.rb`, and `.java` file changes. Set `DEEPDIFFDB_CONFIG` to point at a non-default config path.
 
 ## Using `version commit` in CI
 
-To record a versioned snapshot on every merge to main, add a `version commit` step to your pipeline. Use `--skip-auth` to bypass the GitHub device flow prompt and `--author` to identify the pipeline:
+To record a versioned snapshot on every merge to main, add a `version commit` step. Use `--skip-auth` to bypass the GitHub device flow and `--author` to identify the pipeline:
 
 ```yaml
 # GitHub Actions — snapshot on merge to main
-name: Version Snapshot
-
 on:
   push:
     branches: [main]
@@ -144,8 +215,9 @@ jobs:
 
 ## Tips
 
-- **Pin the version** in CI with `DEEPDIFFDB_VERSION: v1.2.0` to avoid unexpected upgrades.
+- **Pin the version** with `DEEPDIFFDB_VERSION: v1.3.0` to avoid unexpected upgrades.
 - **Cache the binary** between runs using your CI platform's cache action.
-- **Fail fast on schema changes** — set `--exit-code` (coming in a future release) to fail CI if any drift is detected.
-- **Use Docker** in CI for a hermetic environment: `docker run ghcr.io/iamvirul/deepdiff-db:latest diff`.
-- **Skip GitHub auth in CI** — always pass `--skip-auth` to `version init` in pipelines; use `--author "ci/<platform>"` on `version commit` to identify the pipeline as the committer.
+- **Silent schema gate** — use `schema-diff --quiet` for a fully silent check; exit code `0` = no drift, non-zero = drift or error.
+- **Temporary output dirs** — use `--output-dir /tmp/deepdiff-$$` so ephemeral runners don't need a writable workspace.
+- **Use Docker** for a hermetic environment: `docker run ghcr.io/iamvirul/deepdiff-db:latest diff`.
+- **Skip GitHub auth in CI** — always pass `--skip-auth` to `version init` in pipelines; use `--author "ci/<platform>"` on `version commit`.


### PR DESCRIPTION
Closes #17

## Summary

- Add `--quiet` and `--output-dir` flags to `schema-diff` for clean CI/pre-commit use
- Add `.pre-commit-hooks.yaml` for official pre-commit framework integration
- Add `examples/cicd/Jenkinsfile` declarative pipeline example
- Fix broken `--output-format json` references in GitHub Actions and GitLab CI examples
- Update CHANGELOG (v1.3.0), ROADMAP, command docs, and CI/CD deployment guide

## Changes

### CLI (`cmd/deepdiffdb/main.go`)
- `--quiet`: suppresses progress bars, metrics, and informational stdout; auto-raises log level `info → warn` so the tool is fully silent on success. Explicit `--log-level debug` overrides.
- `--output-dir`: overrides `output.dir` from config at runtime — lets pre-commit hooks and CI runners redirect output to a temp dir without touching the config file.

### New files
- `.pre-commit-hooks.yaml` — official pre-commit framework hooks definition; users reference the repo directly in `.pre-commit-config.yaml`
- `examples/cicd/Jenkinsfile` — Declarative Pipeline with masked credential injection, schema-diff + data diff stages, UNSTABLE on drift, artifact archiving

### Bug fixes
- `examples/cicd/github-actions.yml` — removed non-existent `--output-format json` flag; fixed jq queries to match actual JSON structure (`schema_diff.json`, `content_diff.json`)
- `examples/cicd/gitlab-ci.yml` — same fix

### Docs
- `website/docs/commands/schema-diff.md` — new flags added to reference table + CI examples
- `website/docs/deployment/cicd.md` — Jenkins section, pre-commit framework usage, updated tips (removed stale "coming in a future release" note)
- `CHANGELOG.md` — v1.3.0 entry
- `ROADMAP.md` — issue #17 marked done, v1.3.0 completed section added

## Test plan

- [ ] `schema-diff --quiet` produces zero output on success
- [ ] `schema-diff --quiet` still exits non-zero and surfaces WARN + error message on drift
- [ ] `schema-diff --quiet --log-level debug` shows debug logs (user override respected)
- [ ] `schema-diff --output-dir /tmp/xyz` writes `schema_diff.json` and `schema_diff.txt` to the override path
- [ ] All unit test suites pass (`go test ./...` excluding Docker integration tests)
- [ ] MySQL and PostgreSQL Docker integration tests pass