### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, development ]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/deepdiff-db/security/code-scanning/8](https://github.com/iamvirul/deepdiff-db/security/code-scanning/8)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit restricted token access unless overridden.  
Best minimal safe fix (without changing functionality): set:

- `contents: read`

This supports `actions/checkout` and typical read-only workflow operations while removing implicit write privileges from defaults.  
Change location: near the top of the workflow, after `on:` (or after `name:`/`on:` block) and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration permissions to enhance security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->