### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, development ]
 
+permissions:
+  contents: read
+
 jobs:
   security:
     name: Security Scan


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/deepdiff-db/security/code-scanning/6](https://github.com/iamvirul/deepdiff-db/security/code-scanning/6)

Add an explicit `permissions` block to the workflow (or job).  
Best minimal fix without changing functionality: set workflow-level permissions to read-only for repository contents.

For this file, insert:

```yml
permissions:
  contents: read
```

directly under the `on:` trigger block (before `jobs:`). This applies to all jobs unless overridden and satisfies CodeQL’s requirement while preserving current behavior for checkout and scanning steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
