### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -11,6 +11,9 @@ on:
       - action.yml
       - .github/workflows/action-test.yml
 
+permissions:
+  contents: read
+
 jobs:
   test-action:
     name: Test deepdiff-db action (SQLite)


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/deepdiff-db/security/code-scanning/3](https://github.com/iamvirul/deepdiff-db/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/action-test.yml` at the workflow root (after `on:` and before `jobs:`) so it applies to all jobs in this workflow.  
For this workflow, the minimal and correct setting is:

- `contents: read`

This preserves current functionality (checkout and running local commands) while ensuring token access is explicitly constrained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
