### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     name: Build All Platforms


### PR DESCRIPTION
Potential fix for [https://github.com/iamvirul/deepdiff-db/security/code-scanning/2](https://github.com/iamvirul/deepdiff-db/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/build.yml` so the workflow token is least-privileged.  
Best fix without changing behavior: add workflow-level permissions directly under the trigger section and before `jobs`, with:

- `contents: read` (needed for `actions/checkout`)
- `actions: read` (safe/explicit for action metadata access)

No other permissions are required for the shown steps. This preserves existing functionality while preventing broader default token scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
