### PR TITLE
Remove PR title validation job from workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,37 +16,6 @@ permissions:
   issues: write
 
 jobs:
-  # Validate PR title follows conventional commits
-  validate-pr-title:
-    name: Validate PR Title
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    permissions:
-      pull-requests: write
-      statuses: write
-
-    steps:
-      - name: Check PR title format
-        uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            docs
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            chore
-          requireScope: false
-          subjectPattern: ^[A-Z].+$
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            must start with an uppercase letter.
 
   # Ensure no merge conflicts
   check-merge-conflicts:


### PR DESCRIPTION
## Description

Removed the job for validating PR title format from the workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed PR title validation check from the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->