### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-04-19
+## [1.3.0] - 2026-04-23
 
 ### Added
 - **CI/CD Integration** (issue #17)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Release](https://img.shields.io/github/v/release/iamvirul/deepdiff-db?color=6366f1)](https://github.com/iamvirul/deepdiff-db/releases/latest)
 [![codecov](https://codecov.io/gh/iamvirul/deepdiff-db/branch/main/graph/badge.svg?token=Y9IORTUBAH)](https://codecov.io/gh/iamvirul/deepdiff-db)
 [![Go Report Card](https://goreportcard.com/badge/github.com/iamvirul/deepdiff-db)](https://goreportcard.com/report/github.com/iamvirul/deepdiff-db)
-[![Go Version](https://img.shields.io/badge/go-1.25.8-00ADD8?logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/go-1.25.9-00ADD8?logo=go)](https://go.dev/)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-2496ED?logo=docker)](https://github.com/iamvirul/deepdiff-db/pkgs/container/deepdiff-db)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-iamvirul.github.io-6366f1)](https://iamvirul.github.io/deepdiff-db/)

--- a/website/docs/deployment/docker.md
+++ b/website/docs/deployment/docker.md
@@ -13,7 +13,7 @@ DeepDiff DB ships a minimal, scratch-based Docker image with zero native depende
 docker pull ghcr.io/iamvirul/deepdiff-db:latest
 
 # Specific version
-docker pull ghcr.io/iamvirul/deepdiff-db:v1.2.0
+docker pull ghcr.io/iamvirul/deepdiff-db:v1.3.0
 ```
 
 ## Run a diff
@@ -52,8 +52,8 @@ Copy and adapt `docker-compose.example.yml` to point at your real databases.
 
 ```bash
 docker build \
-  --build-arg VERSION=v1.2.0 \
-  -t deepdiff-db:v1.2.0 \
+  --build-arg VERSION=v1.3.0 \
+  -t deepdiff-db:v1.3.0 \
   .
 ```
 
@@ -70,8 +70,8 @@ The multi-stage build compiles a statically linked binary with `CGO_ENABLED=0`, 
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `v1.2.0` | Specific version |
-| `v1.2.0-amd64` | Architecture-specific manifest |
-| `v1.2.0-arm64` | Architecture-specific manifest |
+| `v1.3.0` | Specific version |
+| `v1.3.0-amd64` | Architecture-specific manifest |
+| `v1.3.0-arm64` | Architecture-specific manifest |
 
 Multi-arch manifests cover `linux/amd64` and `linux/arm64`.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -148,14 +148,14 @@ deepdiffdb --version
 Expected output:
 
 ```
-DeepDiff DB v1.2.0
+DeepDiff DB v1.3.0
 ```
 
 ---
 
 ## Build from Source
 
-Requires Go 1.25.8 or later.
+Requires Go 1.25.9 or later.
 
 ```bash
 go install github.com/iamvirul/deepdiff-db/cmd/deepdiffdb@latest

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
         { type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs' },
         { to: '/blog', label: 'Blog', position: 'left' },
         { href: 'https://github.com/iamvirul/deepdiff-db', label: 'GitHub', position: 'right' },
-        { href: 'https://github.com/iamvirul/deepdiff-db/releases', label: 'v1.2', position: 'right' },
+        { href: 'https://github.com/iamvirul/deepdiff-db/releases', label: 'v1.3', position: 'right' },
       ],
     },
     footer: {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -131,7 +131,7 @@ export default function Home() {
       <div className={styles.hero}>
         <div className={styles.heroBg} />
         <div className={styles.heroContent}>
-          <div className={styles.heroBadge}>v1.2 — Verified authorship & CI/CD hardening</div>
+          <div className={styles.heroBadge}>v1.3 — CI/CD Integration</div>
           <h1 className={styles.heroTitle}>
             Database diff that<br />
             <span className={styles.heroGradient}>actually ships</span>


### PR DESCRIPTION
## v1.3.0 Release

This PR bumps all version references to v1.3.0 in preparation for the release tag.

### Version changes
- `website/docusaurus.config.js` — navbar label `v1.2` → `v1.3`
- `website/src/pages/index.js` — hero badge `v1.2 — Verified authorship & CI/CD hardening` → `v1.3 — CI/CD Integration`
- `website/docs/getting-started/installation.md` — expected version output `v1.2.0` → `v1.3.0`, min Go `1.25.8` → `1.25.9`
- `website/docs/deployment/docker.md` — image tag examples `v1.2.0` → `v1.3.0`
- `README.md` — Go badge `1.25.8` → `1.25.9`

### After merge
Tag main with `v1.3.0` to trigger GoReleaser (builds cross-platform binaries, Docker multi-arch images, Homebrew formula update).