### PR TITLE
Phase 1: Model and Configuration Foundation (Views, Routines, Triggers, Sequences)

### DIFF
--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -86,11 +86,99 @@ type PrimaryKeyDiff struct {
 	DevColumns  []string `json:"dev_columns,omitempty"`
 }
 
-// DiffResult aggregates all table diffs.
+// ViewDiff captures differences for a single view across prod/dev.
+type ViewDiff struct {
+	Name                  string `json:"view_name"`
+	MissingInProd         bool   `json:"missing_in_prod,omitempty"`
+	MissingInDev          bool   `json:"missing_in_dev,omitempty"`
+	DefinitionDiffers     bool   `json:"definition_differs,omitempty"`
+	ProdDefinition        string `json:"prod_definition,omitempty"`
+	DevDefinition         string `json:"dev_definition,omitempty"`
+	IsMaterializedDiffers bool   `json:"is_materialized_differs,omitempty"`
+	ProdIsMaterialized    *bool  `json:"prod_is_materialized,omitempty"`
+	DevIsMaterialized     *bool  `json:"dev_is_materialized,omitempty"`
+}
+
+// RoutineDiff captures differences for a stored procedure or function across prod/dev.
+type RoutineDiff struct {
+	Name              string `json:"routine_name"`
+	MissingInProd     bool   `json:"missing_in_prod,omitempty"`
+	MissingInDev      bool   `json:"missing_in_dev,omitempty"`
+	DefinitionDiffers bool   `json:"definition_differs,omitempty"`
+	ProdDefinition    string `json:"prod_definition,omitempty"`
+	DevDefinition     string `json:"dev_definition,omitempty"`
+	KindDiffers       bool   `json:"kind_differs,omitempty"`
+	ProdKind          string `json:"prod_kind,omitempty"`
+	DevKind           string `json:"dev_kind,omitempty"`
+	ReturnTypeDiffers bool   `json:"return_type_differs,omitempty"`
+	ProdReturnType    string `json:"prod_return_type,omitempty"`
+	DevReturnType     string `json:"dev_return_type,omitempty"`
+	LanguageDiffers   bool   `json:"language_differs,omitempty"`
+	ProdLanguage      string `json:"prod_language,omitempty"`
+	DevLanguage       string `json:"dev_language,omitempty"`
+}
+
+// TriggerDiff captures differences for a trigger across prod/dev.
+type TriggerDiff struct {
+	Name              string `json:"trigger_name"`
+	MissingInProd     bool   `json:"missing_in_prod,omitempty"`
+	MissingInDev      bool   `json:"missing_in_dev,omitempty"`
+	DefinitionDiffers bool   `json:"definition_differs,omitempty"`
+	ProdDefinition    string `json:"prod_definition,omitempty"`
+	DevDefinition     string `json:"dev_definition,omitempty"`
+	TimingDiffers     bool   `json:"timing_differs,omitempty"`
+	ProdTiming        string `json:"prod_timing,omitempty"`
+	DevTiming         string `json:"dev_timing,omitempty"`
+	EventDiffers      bool   `json:"event_differs,omitempty"`
+	ProdEvent         string `json:"prod_event,omitempty"`
+	DevEvent          string `json:"dev_event,omitempty"`
+	ForEachRowDiffers bool   `json:"for_each_row_differs,omitempty"`
+	ProdForEachRow    *bool  `json:"prod_for_each_row,omitempty"`
+	DevForEachRow     *bool  `json:"dev_for_each_row,omitempty"`
+}
+
+// SequenceDiff captures differences for a sequence object across prod/dev.
+type SequenceDiff struct {
+	Name              string `json:"sequence_name"`
+	MissingInProd     bool   `json:"missing_in_prod,omitempty"`
+	MissingInDev      bool   `json:"missing_in_dev,omitempty"`
+	StartValueDiffers bool   `json:"start_value_differs,omitempty"`
+	ProdStartValue    int64  `json:"prod_start_value,omitempty"`
+	DevStartValue     int64  `json:"dev_start_value,omitempty"`
+	IncrementDiffers  bool   `json:"increment_differs,omitempty"`
+	ProdIncrement     int64  `json:"prod_increment,omitempty"`
+	DevIncrement      int64  `json:"dev_increment,omitempty"`
+	MinValueDiffers   bool   `json:"min_value_differs,omitempty"`
+	ProdMinValue      int64  `json:"prod_min_value,omitempty"`
+	DevMinValue       int64  `json:"dev_min_value,omitempty"`
+	MaxValueDiffers   bool   `json:"max_value_differs,omitempty"`
+	ProdMaxValue      int64  `json:"prod_max_value,omitempty"`
+	DevMaxValue       int64  `json:"dev_max_value,omitempty"`
+	CacheSizeDiffers  bool   `json:"cache_size_differs,omitempty"`
+	ProdCacheSize     int64  `json:"prod_cache_size,omitempty"`
+	DevCacheSize      int64  `json:"dev_cache_size,omitempty"`
+	CycleDiffers      bool   `json:"cycle_differs,omitempty"`
+	ProdCycle         *bool  `json:"prod_cycle,omitempty"`
+	DevCycle          *bool  `json:"dev_cycle,omitempty"`
+}
+
+// DiffResult aggregates all schema-level diffs.
 type DiffResult struct {
-	Tables        []TableDiff `json:"tables"`
-	AddedTables   []Table     `json:"added_tables,omitempty"`   // Full table definitions for CREATE TABLE
-	RemovedTables []string    `json:"removed_tables,omitempty"` // Table names for DROP TABLE
+	Tables           []TableDiff    `json:"tables"`
+	AddedTables      []Table        `json:"added_tables,omitempty"`    // Full table definitions for CREATE TABLE
+	RemovedTables    []string       `json:"removed_tables,omitempty"`  // Table names for DROP TABLE
+	AddedViews       []View         `json:"added_views,omitempty"`     // Full view definitions for CREATE VIEW
+	RemovedViews     []string       `json:"removed_views,omitempty"`   // View names for DROP VIEW
+	ModifiedViews    []ViewDiff     `json:"modified_views,omitempty"`  // Views present in both but differing
+	AddedRoutines    []Routine      `json:"added_routines,omitempty"`  // Full routine definitions for CREATE
+	RemovedRoutines  []string       `json:"removed_routines,omitempty"`  // Routine names for DROP
+	ModifiedRoutines []RoutineDiff  `json:"modified_routines,omitempty"` // Routines present in both but differing
+	AddedTriggers    []Trigger      `json:"added_triggers,omitempty"`  // Full trigger definitions for CREATE
+	RemovedTriggers  []string       `json:"removed_triggers,omitempty"`  // Trigger names for DROP
+	ModifiedTriggers []TriggerDiff  `json:"modified_triggers,omitempty"` // Triggers present in both but differing
+	AddedSequences   []Sequence     `json:"added_sequences,omitempty"`   // Full sequence definitions for CREATE
+	RemovedSequences []string       `json:"removed_sequences,omitempty"` // Sequence names for DROP
+	ModifiedSequences []SequenceDiff `json:"modified_sequences,omitempty"` // Sequences present in both but differing
 }
 
 // DiffSchemas compares two Schema values and returns a DiffResult that describes table- and column-level differences between them.
@@ -163,14 +251,18 @@ func DiffSchemas(prod, dev *Schema) DiffResult {
 	return result
 }
 
-// HasDrift indicates whether any differences were found.
+// HasDrift indicates whether any differences were found across tables, views,
+// routines, triggers, or sequences.
 func (d DiffResult) HasDrift() bool {
 	for _, t := range d.Tables {
 		if t.HasDifferences {
 			return true
 		}
 	}
-	return false
+	return len(d.AddedViews) > 0 || len(d.RemovedViews) > 0 || len(d.ModifiedViews) > 0 ||
+		len(d.AddedRoutines) > 0 || len(d.RemovedRoutines) > 0 || len(d.ModifiedRoutines) > 0 ||
+		len(d.AddedTriggers) > 0 || len(d.RemovedTriggers) > 0 || len(d.ModifiedTriggers) > 0 ||
+		len(d.AddedSequences) > 0 || len(d.RemovedSequences) > 0 || len(d.ModifiedSequences) > 0
 }
 
 // diffColumns computes column-level differences between prodCols and devCols.

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -101,21 +101,24 @@ type ViewDiff struct {
 
 // RoutineDiff captures differences for a stored procedure or function across prod/dev.
 type RoutineDiff struct {
-	Name              string `json:"routine_name"`
-	MissingInProd     bool   `json:"missing_in_prod,omitempty"`
-	MissingInDev      bool   `json:"missing_in_dev,omitempty"`
-	DefinitionDiffers bool   `json:"definition_differs,omitempty"`
-	ProdDefinition    string `json:"prod_definition,omitempty"`
-	DevDefinition     string `json:"dev_definition,omitempty"`
-	KindDiffers       bool   `json:"kind_differs,omitempty"`
-	ProdKind          string `json:"prod_kind,omitempty"`
-	DevKind           string `json:"dev_kind,omitempty"`
-	ReturnTypeDiffers bool   `json:"return_type_differs,omitempty"`
-	ProdReturnType    string `json:"prod_return_type,omitempty"`
-	DevReturnType     string `json:"dev_return_type,omitempty"`
-	LanguageDiffers   bool   `json:"language_differs,omitempty"`
-	ProdLanguage      string `json:"prod_language,omitempty"`
-	DevLanguage       string `json:"dev_language,omitempty"`
+	Name              string             `json:"routine_name"`
+	MissingInProd     bool               `json:"missing_in_prod,omitempty"`
+	MissingInDev      bool               `json:"missing_in_dev,omitempty"`
+	DefinitionDiffers bool               `json:"definition_differs,omitempty"`
+	ProdDefinition    string             `json:"prod_definition,omitempty"`
+	DevDefinition     string             `json:"dev_definition,omitempty"`
+	KindDiffers       bool               `json:"kind_differs,omitempty"`
+	ProdKind          string             `json:"prod_kind,omitempty"`
+	DevKind           string             `json:"dev_kind,omitempty"`
+	ReturnTypeDiffers bool               `json:"return_type_differs,omitempty"`
+	ProdReturnType    string             `json:"prod_return_type,omitempty"`
+	DevReturnType     string             `json:"dev_return_type,omitempty"`
+	LanguageDiffers   bool               `json:"language_differs,omitempty"`
+	ProdLanguage      string             `json:"prod_language,omitempty"`
+	DevLanguage       string             `json:"dev_language,omitempty"`
+	ParametersDiffers bool               `json:"parameters_differs,omitempty"`
+	ProdParameters    []RoutineParameter `json:"prod_parameters,omitempty"`
+	DevParameters     []RoutineParameter `json:"dev_parameters,omitempty"`
 }
 
 // TriggerDiff captures differences for a trigger across prod/dev.
@@ -135,6 +138,9 @@ type TriggerDiff struct {
 	ForEachRowDiffers bool   `json:"for_each_row_differs,omitempty"`
 	ProdForEachRow    *bool  `json:"prod_for_each_row,omitempty"`
 	DevForEachRow     *bool  `json:"dev_for_each_row,omitempty"`
+	OwnerTableDiffers bool   `json:"owner_table_differs,omitempty"`
+	ProdOwnerTable    string `json:"prod_owner_table,omitempty"`
+	DevOwnerTable     string `json:"dev_owner_table,omitempty"`
 }
 
 // SequenceDiff captures differences for a sequence object across prod/dev.

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -308,6 +308,219 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 		stmts = append(stmts, "")
 	}
 
+	// Process removed views (DROP VIEW)
+	if len(diff.RemovedViews) > 0 {
+		stmts = append(stmts, "-- DROP VIEWS (present in prod but not in dev)")
+		stmts = append(stmts, "-- WARNING: These operations will delete view definitions!")
+		if opts.ConfirmDestructive {
+			stmts = append(stmts, "-- IMPORTANT: Review carefully before executing!")
+		}
+		for _, viewName := range diff.RemovedViews {
+			dropStmt := fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(viewName, driver))
+			if !opts.AllowDropView {
+				dropStmt = "-- " + dropStmt
+			}
+			stmts = append(stmts, dropStmt)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process added views (CREATE VIEW)
+	if len(diff.AddedViews) > 0 {
+		stmts = append(stmts, "-- CREATE VIEWS (present in dev but not in prod)")
+		for _, view := range diff.AddedViews {
+			var createStmt string
+			if view.IsMaterialized {
+				createStmt = fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+			} else {
+				createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+			}
+			stmts = append(stmts, createStmt)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process modified views
+	if len(diff.ModifiedViews) > 0 {
+		stmts = append(stmts, "-- MODIFIED VIEWS (differ between prod and dev)")
+		stmts = append(stmts, "-- NOTE: To modify a view, drop and recreate it. Manual review required.")
+		for _, viewDiff := range diff.ModifiedViews {
+			stmts = append(stmts, fmt.Sprintf("-- View %s differs between prod and dev", viewDiff.Name))
+			if viewDiff.DefinitionDiffers {
+				stmts = append(stmts, "--   Definition differs")
+			}
+			if viewDiff.IsMaterializedDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   IsMaterialized: prod=%v dev=%v", *viewDiff.ProdIsMaterialized, *viewDiff.DevIsMaterialized))
+			}
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process removed routines (DROP PROCEDURE/FUNCTION)
+	if len(diff.RemovedRoutines) > 0 {
+		stmts = append(stmts, "-- DROP ROUTINES (present in prod but not in dev)")
+		stmts = append(stmts, "-- WARNING: These operations will delete stored procedures/functions!")
+		if opts.ConfirmDestructive {
+			stmts = append(stmts, "-- IMPORTANT: Review carefully before executing!")
+		}
+		for _, routineName := range diff.RemovedRoutines {
+			// Note: We don't know the routine kind here, so we use a generic comment
+			dropStmt := fmt.Sprintf("-- DROP PROCEDURE/FUNCTION %s; -- Manual review required to determine routine type", quoteIdentifier(routineName, driver))
+			if !opts.AllowDropRoutine {
+				dropStmt = "-- " + dropStmt
+			}
+			stmts = append(stmts, dropStmt)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process added routines (CREATE PROCEDURE/FUNCTION)
+	if len(diff.AddedRoutines) > 0 {
+		stmts = append(stmts, "-- CREATE ROUTINES (present in dev but not in prod)")
+		for _, routine := range diff.AddedRoutines {
+			stmts = append(stmts, routine.Definition)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process modified routines
+	if len(diff.ModifiedRoutines) > 0 {
+		stmts = append(stmts, "-- MODIFIED ROUTINES (differ between prod and dev)")
+		stmts = append(stmts, "-- NOTE: To modify a routine, drop and recreate it. Manual review required.")
+		for _, routineDiff := range diff.ModifiedRoutines {
+			stmts = append(stmts, fmt.Sprintf("-- Routine %s differs between prod and dev", routineDiff.Name))
+			if routineDiff.DefinitionDiffers {
+				stmts = append(stmts, "--   Definition differs")
+			}
+			if routineDiff.KindDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   Kind: prod=%s dev=%s", routineDiff.ProdKind, routineDiff.DevKind))
+			}
+			if routineDiff.ReturnTypeDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   ReturnType: prod=%s dev=%s", routineDiff.ProdReturnType, routineDiff.DevReturnType))
+			}
+			if routineDiff.LanguageDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   Language: prod=%s dev=%s", routineDiff.ProdLanguage, routineDiff.DevLanguage))
+			}
+			if routineDiff.ParametersDiffers {
+				stmts = append(stmts, "--   Parameters differ")
+			}
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process removed triggers (DROP TRIGGER)
+	if len(diff.RemovedTriggers) > 0 {
+		stmts = append(stmts, "-- DROP TRIGGERS (present in prod but not in dev)")
+		stmts = append(stmts, "-- WARNING: These operations will delete triggers!")
+		if opts.ConfirmDestructive {
+			stmts = append(stmts, "-- IMPORTANT: Review carefully before executing!")
+		}
+		for _, triggerName := range diff.RemovedTriggers {
+			dropStmt := fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
+			if !opts.AllowDropTrigger {
+				dropStmt = "-- " + dropStmt
+			}
+			stmts = append(stmts, dropStmt)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process added triggers (CREATE TRIGGER)
+	if len(diff.AddedTriggers) > 0 {
+		stmts = append(stmts, "-- CREATE TRIGGERS (present in dev but not in prod)")
+		for _, trigger := range diff.AddedTriggers {
+			stmts = append(stmts, trigger.Definition)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process modified triggers
+	if len(diff.ModifiedTriggers) > 0 {
+		stmts = append(stmts, "-- MODIFIED TRIGGERS (differ between prod and dev)")
+		stmts = append(stmts, "-- NOTE: To modify a trigger, drop and recreate it. Manual review required.")
+		for _, triggerDiff := range diff.ModifiedTriggers {
+			stmts = append(stmts, fmt.Sprintf("-- Trigger %s differs between prod and dev", triggerDiff.Name))
+			if triggerDiff.DefinitionDiffers {
+				stmts = append(stmts, "--   Definition differs")
+			}
+			if triggerDiff.TimingDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   Timing: prod=%s dev=%s", triggerDiff.ProdTiming, triggerDiff.DevTiming))
+			}
+			if triggerDiff.EventDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   Event: prod=%s dev=%s", triggerDiff.ProdEvent, triggerDiff.DevEvent))
+			}
+			if triggerDiff.ForEachRowDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   ForEachRow: prod=%v dev=%v", *triggerDiff.ProdForEachRow, *triggerDiff.DevForEachRow))
+			}
+			if triggerDiff.OwnerTableDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   OwnerTable: prod=%s dev=%s", triggerDiff.ProdOwnerTable, triggerDiff.DevOwnerTable))
+			}
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process removed sequences (DROP SEQUENCE)
+	if len(diff.RemovedSequences) > 0 {
+		stmts = append(stmts, "-- DROP SEQUENCES (present in prod but not in dev)")
+		stmts = append(stmts, "-- WARNING: These operations will delete sequences!")
+		if opts.ConfirmDestructive {
+			stmts = append(stmts, "-- IMPORTANT: Review carefully before executing!")
+		}
+		for _, sequenceName := range diff.RemovedSequences {
+			dropStmt := fmt.Sprintf("DROP SEQUENCE %s;", quoteIdentifier(sequenceName, driver))
+			if !opts.AllowDropSequence {
+				dropStmt = "-- " + dropStmt
+			}
+			stmts = append(stmts, dropStmt)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process added sequences (CREATE SEQUENCE)
+	if len(diff.AddedSequences) > 0 {
+		stmts = append(stmts, "-- CREATE SEQUENCES (present in dev but not in prod)")
+		for _, seq := range diff.AddedSequences {
+			createStmt := fmt.Sprintf("CREATE SEQUENCE %s START WITH %d INCREMENT BY %d MINVALUE %d MAXVALUE %d CACHE %d",
+				quoteIdentifier(seq.Name, driver), seq.StartValue, seq.Increment, seq.MinValue, seq.MaxValue, seq.CacheSize)
+			if seq.Cycle {
+				createStmt += " CYCLE"
+			} else {
+				createStmt += " NO CYCLE"
+			}
+			createStmt += ";"
+			stmts = append(stmts, createStmt)
+		}
+		stmts = append(stmts, "")
+	}
+
+	// Process modified sequences
+	if len(diff.ModifiedSequences) > 0 {
+		stmts = append(stmts, "-- MODIFIED SEQUENCES (differ between prod and dev)")
+		stmts = append(stmts, "-- NOTE: Sequence modifications may require manual intervention. Review carefully.")
+		for _, seqDiff := range diff.ModifiedSequences {
+			stmts = append(stmts, fmt.Sprintf("-- Sequence %s differs between prod and dev", seqDiff.Name))
+			if seqDiff.StartValueDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   StartValue: prod=%d dev=%d", seqDiff.ProdStartValue, seqDiff.DevStartValue))
+			}
+			if seqDiff.IncrementDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   Increment: prod=%d dev=%d", seqDiff.ProdIncrement, seqDiff.DevIncrement))
+			}
+			if seqDiff.MinValueDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   MinValue: prod=%d dev=%d", seqDiff.ProdMinValue, seqDiff.DevMinValue))
+			}
+			if seqDiff.MaxValueDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   MaxValue: prod=%d dev=%d", seqDiff.ProdMaxValue, seqDiff.DevMaxValue))
+			}
+			if seqDiff.CacheSizeDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   CacheSize: prod=%d dev=%d", seqDiff.ProdCacheSize, seqDiff.DevCacheSize))
+			}
+			if seqDiff.CycleDiffers {
+				stmts = append(stmts, fmt.Sprintf("--   Cycle: prod=%v dev=%v", *seqDiff.ProdCycle, *seqDiff.DevCycle))
+			}
+		}
+		stmts = append(stmts, "")
+	}
+
 	// Add transaction commit
 	stmts = append(stmts, "COMMIT;")
 

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -331,7 +331,21 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 		for _, view := range diff.AddedViews {
 			var createStmt string
 			if view.IsMaterialized {
-				createStmt = fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+				// Check if the driver supports materialized views
+				switch driver {
+				case "postgres", "postgresql":
+					// PostgreSQL supports materialized views
+					createStmt = fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+				case "mysql", "sqlite", "mssql", "sqlserver":
+					// These drivers don't support materialized views - emit manual review comment
+					stmts = append(stmts, fmt.Sprintf("-- Manual review required to determine materialized view support for %s", driver))
+					stmts = append(stmts, fmt.Sprintf("-- Materialized view requested but not supported; creating standard view instead:"))
+					createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+				default:
+					// Unknown driver - emit manual review comment
+					stmts = append(stmts, fmt.Sprintf("-- Manual review required to determine materialized view support for %s", driver))
+					createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+				}
 			} else {
 				createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
 			}
@@ -364,9 +378,31 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 			stmts = append(stmts, "-- IMPORTANT: Review carefully before executing!")
 		}
 		for _, routineName := range diff.RemovedRoutines {
-			// Note: We don't know the routine kind here, so we use a generic comment
-			dropStmt := fmt.Sprintf("-- DROP PROCEDURE/FUNCTION %s; -- Manual review required to determine routine type", quoteIdentifier(routineName, driver))
-			if !opts.AllowDropRoutine {
+			// Look up the routine kind from the production schema
+			var dropStmt string
+			if prodSchema != nil {
+				if routine, ok := prodSchema.Routines[routineName]; ok {
+					// We know the kind - emit the proper DROP statement
+					routineType := strings.ToUpper(routine.Kind)
+					if routineType == "FUNCTION" {
+						dropStmt = fmt.Sprintf("DROP FUNCTION %s;", quoteIdentifier(routineName, driver))
+					} else if routineType == "PROCEDURE" {
+						dropStmt = fmt.Sprintf("DROP PROCEDURE %s;", quoteIdentifier(routineName, driver))
+					} else {
+						// Unknown kind - use generic comment
+						dropStmt = fmt.Sprintf("-- DROP PROCEDURE/FUNCTION %s; -- Manual review required: unknown routine kind '%s'", quoteIdentifier(routineName, driver), routine.Kind)
+					}
+				} else {
+					// Routine not found in production schema
+					dropStmt = fmt.Sprintf("-- DROP PROCEDURE/FUNCTION %s; -- Manual review required: routine not found in production schema", quoteIdentifier(routineName, driver))
+				}
+			} else {
+				// No production schema available
+				dropStmt = fmt.Sprintf("-- DROP PROCEDURE/FUNCTION %s; -- Manual review required to determine routine type", quoteIdentifier(routineName, driver))
+			}
+
+			// Only prefix with "-- " if AllowDropRoutine is false and the statement is not already commented
+			if !opts.AllowDropRoutine && !strings.HasPrefix(dropStmt, "-- ") {
 				dropStmt = "-- " + dropStmt
 			}
 			stmts = append(stmts, dropStmt)
@@ -416,8 +452,46 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 			stmts = append(stmts, "-- IMPORTANT: Review carefully before executing!")
 		}
 		for _, triggerName := range diff.RemovedTriggers {
-			dropStmt := fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
-			if !opts.AllowDropTrigger {
+			var dropStmt string
+			// Look up the trigger's table from the production schema
+			if prodSchema != nil {
+				if trigger, ok := prodSchema.Triggers[triggerName]; ok {
+					// We know the table - emit the proper DROP statement
+					switch driver {
+					case "postgres", "postgresql":
+						// PostgreSQL requires: DROP TRIGGER <name> ON <table>
+						dropStmt = fmt.Sprintf("DROP TRIGGER %s ON %s;", quoteIdentifier(triggerName, driver), quoteIdentifier(trigger.Table, driver))
+					case "mysql":
+						// MySQL requires: DROP TRIGGER <name> (table not needed)
+						dropStmt = fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
+					case "sqlite":
+						// SQLite requires: DROP TRIGGER <name> (table not needed)
+						dropStmt = fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
+					case "mssql", "sqlserver":
+						// MSSQL requires: DROP TRIGGER <name> (table not needed, or schema-qualified)
+						dropStmt = fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
+					case "oracle":
+						// Oracle requires: DROP TRIGGER <name> (table not needed)
+						dropStmt = fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
+					default:
+						// Unknown driver - emit generic DROP TRIGGER
+						dropStmt = fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
+					}
+				} else {
+					// Trigger not found in production schema
+					dropStmt = fmt.Sprintf("-- DROP TRIGGER %s; -- Manual review required: trigger not found in production schema", quoteIdentifier(triggerName, driver))
+				}
+			} else {
+				// No production schema available - emit generic statement (may fail for PostgreSQL)
+				dropStmt = fmt.Sprintf("DROP TRIGGER %s;", quoteIdentifier(triggerName, driver))
+				if driver == "postgres" || driver == "postgresql" {
+					// Add a comment for PostgreSQL since it requires the table name
+					dropStmt = fmt.Sprintf("-- DROP TRIGGER %s; -- Manual review required: PostgreSQL requires table name (DROP TRIGGER <name> ON <table>)", quoteIdentifier(triggerName, driver))
+				}
+			}
+
+			// Only prefix with "-- " if AllowDropTrigger is false and the statement is not already commented
+			if !opts.AllowDropTrigger && !strings.HasPrefix(dropStmt, "-- ") {
 				dropStmt = "-- " + dropStmt
 			}
 			stmts = append(stmts, dropStmt)
@@ -429,6 +503,10 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 	if len(diff.AddedTriggers) > 0 {
 		stmts = append(stmts, "-- CREATE TRIGGERS (present in dev but not in prod)")
 		for _, trigger := range diff.AddedTriggers {
+			// Guard against empty Definition
+			if trigger.Definition == "" {
+				return "", fmt.Errorf("trigger %s on table %s has empty Definition; cannot generate CREATE TRIGGER statement", trigger.Name, trigger.Table)
+			}
 			stmts = append(stmts, trigger.Definition)
 		}
 		stmts = append(stmts, "")

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -29,6 +29,22 @@ type MigrationOptions struct {
 	// When false (default), PRIMARY KEY modification statements are commented out for safety.
 	AllowModifyPrimaryKey bool
 
+	// AllowDropView controls whether DROP VIEW statements are uncommented.
+	// When false (default), DROP VIEW statements are commented out for safety.
+	AllowDropView bool
+
+	// AllowDropRoutine controls whether DROP PROCEDURE/FUNCTION statements are uncommented.
+	// When false (default), DROP PROCEDURE/FUNCTION statements are commented out for safety.
+	AllowDropRoutine bool
+
+	// AllowDropTrigger controls whether DROP TRIGGER statements are uncommented.
+	// When false (default), DROP TRIGGER statements are commented out for safety.
+	AllowDropTrigger bool
+
+	// AllowDropSequence controls whether DROP SEQUENCE statements are uncommented.
+	// When false (default), DROP SEQUENCE statements are commented out for safety.
+	AllowDropSequence bool
+
 	// ConfirmDestructive adds additional warnings for destructive operations.
 	ConfirmDestructive bool
 }

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -339,7 +339,7 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 				case "mysql", "sqlite", "mssql", "sqlserver":
 					// These drivers don't support materialized views - emit manual review comment
 					stmts = append(stmts, fmt.Sprintf("-- Manual review required to determine materialized view support for %s", driver))
-					stmts = append(stmts, fmt.Sprintf("-- Materialized view requested but not supported; creating standard view instead:"))
+					stmts = append(stmts, "-- Materialized view requested but not supported; creating standard view instead:")
 					createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
 				default:
 					// Unknown driver - emit manual review comment

--- a/internal/schema/model.go
+++ b/internal/schema/model.go
@@ -34,7 +34,64 @@ type Table struct {
 	ForeignKeys map[string]ForeignKey `json:"foreign_keys,omitempty"`
 }
 
+// RoutineParameter describes a single parameter of a stored routine.
+// Mode is one of "IN", "OUT", or "INOUT".
+type RoutineParameter struct {
+	Name     string `json:"name"`
+	DataType string `json:"data_type"`
+	Mode     string `json:"mode"` // IN | OUT | INOUT
+}
+
+// View represents a database view.
+// IsMaterialized distinguishes materialized views (e.g. PostgreSQL MATERIALIZED VIEW)
+// from standard views.
+type View struct {
+	Name            string `json:"name"`
+	Definition      string `json:"definition"`
+	IsMaterialized  bool   `json:"is_materialized"`
+}
+
+// Routine represents a stored procedure or function.
+// Kind is typically "PROCEDURE" or "FUNCTION".
+// ReturnType and Language are omitted when not applicable (e.g. procedures).
+type Routine struct {
+	Name       string             `json:"name"`
+	Kind       string             `json:"kind"`
+	Definition string             `json:"definition"`
+	Parameters []RoutineParameter `json:"parameters"`
+	ReturnType string             `json:"return_type,omitempty"`
+	Language   string             `json:"language,omitempty"`
+}
+
+// Trigger represents a database trigger bound to a table.
+// Timing is one of "BEFORE", "AFTER", or "INSTEAD OF".
+// Event is one of "INSERT", "UPDATE", or "DELETE".
+type Trigger struct {
+	Name       string `json:"name"`
+	Table      string `json:"table"`
+	Timing     string `json:"timing"`
+	Event      string `json:"event"`
+	Definition string `json:"definition"`
+	ForEachRow bool   `json:"for_each_row"`
+}
+
+// Sequence represents a database sequence object.
+// Supported on PostgreSQL and Oracle; ignored on drivers that do not have native sequences.
+type Sequence struct {
+	Name       string `json:"name"`
+	StartValue int64  `json:"start_value"`
+	Increment  int64  `json:"increment"`
+	MinValue   int64  `json:"min_value"`
+	MaxValue   int64  `json:"max_value"`
+	CacheSize  int64  `json:"cache_size"`
+	Cycle      bool   `json:"cycle"`
+}
+
 // Schema represents the collection of tables for a database.
 type Schema struct {
-	Tables map[string]Table `json:"tables"`
+	Tables    map[string]Table    `json:"tables"`
+	Views     map[string]View     `json:"views,omitempty"`
+	Routines  map[string]Routine  `json:"routines,omitempty"`
+	Triggers  map[string]Trigger  `json:"triggers,omitempty"`
+	Sequences map[string]Sequence `json:"sequences,omitempty"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,10 +48,14 @@ type DBConfig struct {
 	Database string `yaml:"database"`
 }
 
-// IgnoreConfig defines tables/columns to skip.
+// IgnoreConfig defines tables/columns/views/routines/triggers/sequences to skip during diff.
 type IgnoreConfig struct {
-	Tables  []string `yaml:"tables"`
-	Columns []string `yaml:"columns"`
+	Tables    []string `yaml:"tables"`
+	Columns   []string `yaml:"columns"`
+	Views     []string `yaml:"views,omitempty"`     // View names to exclude from diff
+	Routines  []string `yaml:"routines,omitempty"`  // Routine names to exclude from diff
+	Triggers  []string `yaml:"triggers,omitempty"`  // Trigger names to exclude from diff
+	Sequences []string `yaml:"sequences,omitempty"` // Sequence names to exclude from diff
 }
 
 // OutputConfig defines the output directory for reports and packs.
@@ -80,6 +84,22 @@ type MigrationConfig struct {
 	// AllowModifyPrimaryKey controls whether primary key modification statements are uncommented.
 	// When false (default), PRIMARY KEY modification statements are commented out for safety.
 	AllowModifyPrimaryKey bool `yaml:"allow_modify_primary_key"`
+
+	// AllowDropView controls whether DROP VIEW statements are uncommented.
+	// When false (default), DROP VIEW statements are commented out for safety.
+	AllowDropView bool `yaml:"allow_drop_view"`
+
+	// AllowDropRoutine controls whether DROP PROCEDURE/FUNCTION statements are uncommented.
+	// When false (default), DROP PROCEDURE/FUNCTION statements are commented out for safety.
+	AllowDropRoutine bool `yaml:"allow_drop_routine"`
+
+	// AllowDropTrigger controls whether DROP TRIGGER statements are uncommented.
+	// When false (default), DROP TRIGGER statements are commented out for safety.
+	AllowDropTrigger bool `yaml:"allow_drop_trigger"`
+
+	// AllowDropSequence controls whether DROP SEQUENCE statements are uncommented.
+	// When false (default), DROP SEQUENCE statements are commented out for safety.
+	AllowDropSequence bool `yaml:"allow_drop_sequence"`
 
 	// ConfirmDestructive requires manual confirmation for destructive operations.
 	// When true, destructive operations include additional warnings.

--- a/tests/schema/diff_objects_test.go
+++ b/tests/schema/diff_objects_test.go
@@ -1,0 +1,295 @@
+package schema_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/iamvirul/deepdiff-db/internal/schema"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func emptyDiffResult() schema.DiffResult {
+	return schema.DiffResult{
+		Tables: []schema.TableDiff{},
+	}
+}
+
+// ── omitempty: new slices must be absent from JSON when empty ─────────────────
+
+func TestDiffResult_OmitemptySlices_AbsentWhenEmpty(t *testing.T) {
+	result := emptyDiffResult()
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	s := string(b)
+
+	for _, key := range []string{
+		"added_views", "removed_views", "modified_views",
+		"added_routines", "removed_routines", "modified_routines",
+		"added_triggers", "removed_triggers", "modified_triggers",
+		"added_sequences", "removed_sequences", "modified_sequences",
+	} {
+		if strings.Contains(s, `"`+key+`"`) {
+			t.Errorf("expected %q to be omitted from JSON when nil, but found it in: %s", key, s)
+		}
+	}
+}
+
+// ── omitempty: new slices must appear in JSON when populated ──────────────────
+
+func TestDiffResult_OmitemptySlices_PresentWhenPopulated(t *testing.T) {
+	trueBool := true
+
+	result := schema.DiffResult{
+		Tables: []schema.TableDiff{},
+		AddedViews: []schema.View{
+			{Name: "v_active", Definition: "SELECT 1", IsMaterialized: false},
+		},
+		RemovedViews: []string{"v_old"},
+		ModifiedViews: []schema.ViewDiff{
+			{Name: "v_summary", DefinitionDiffers: true, ProdDefinition: "SELECT 1", DevDefinition: "SELECT 2"},
+		},
+		AddedRoutines: []schema.Routine{
+			{Name: "fn_calc", Kind: "FUNCTION", Definition: "BEGIN RETURN 1; END"},
+		},
+		RemovedRoutines: []string{"fn_legacy"},
+		ModifiedRoutines: []schema.RoutineDiff{
+			{Name: "fn_price", DefinitionDiffers: true},
+		},
+		AddedTriggers: []schema.Trigger{
+			{Name: "trg_audit", Table: "orders", Timing: "AFTER", Event: "INSERT", Definition: "BEGIN END"},
+		},
+		RemovedTriggers: []string{"trg_old"},
+		ModifiedTriggers: []schema.TriggerDiff{
+			{Name: "trg_sync", EventDiffers: true, ProdEvent: "INSERT", DevEvent: "UPDATE"},
+		},
+		AddedSequences: []schema.Sequence{
+			{Name: "seq_order_id", StartValue: 1, Increment: 1},
+		},
+		RemovedSequences: []string{"seq_legacy"},
+		ModifiedSequences: []schema.SequenceDiff{
+			{Name: "seq_user_id", IncrementDiffers: true, ProdIncrement: 1, DevIncrement: 2,
+				ProdCycle: &trueBool, DevCycle: boolPtr(false)},
+		},
+	}
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	s := string(b)
+
+	for _, key := range []string{
+		"added_views", "removed_views", "modified_views",
+		"added_routines", "removed_routines", "modified_routines",
+		"added_triggers", "removed_triggers", "modified_triggers",
+		"added_sequences", "removed_sequences", "modified_sequences",
+	} {
+		if !strings.Contains(s, `"`+key+`"`) {
+			t.Errorf("expected %q to appear in JSON when populated, but it is missing from: %s", key, s)
+		}
+	}
+}
+
+// ── HasDrift with new object types ────────────────────────────────────────────
+
+func TestHasDrift_FalseWhenNoChanges(t *testing.T) {
+	result := schema.DiffResult{Tables: []schema.TableDiff{}}
+	if result.HasDrift() {
+		t.Error("HasDrift() should be false for an empty DiffResult")
+	}
+}
+
+func TestHasDrift_TrueForAddedView(t *testing.T) {
+	result := schema.DiffResult{
+		AddedViews: []schema.View{{Name: "v_new", Definition: "SELECT 1"}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when AddedViews is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForRemovedView(t *testing.T) {
+	result := schema.DiffResult{RemovedViews: []string{"v_old"}}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when RemovedViews is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForModifiedView(t *testing.T) {
+	result := schema.DiffResult{
+		ModifiedViews: []schema.ViewDiff{{Name: "v_summary", DefinitionDiffers: true}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when ModifiedViews is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForAddedRoutine(t *testing.T) {
+	result := schema.DiffResult{
+		AddedRoutines: []schema.Routine{{Name: "fn_new", Kind: "FUNCTION"}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when AddedRoutines is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForRemovedRoutine(t *testing.T) {
+	result := schema.DiffResult{RemovedRoutines: []string{"fn_old"}}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when RemovedRoutines is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForModifiedRoutine(t *testing.T) {
+	result := schema.DiffResult{
+		ModifiedRoutines: []schema.RoutineDiff{{Name: "fn_price", DefinitionDiffers: true}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when ModifiedRoutines is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForAddedTrigger(t *testing.T) {
+	result := schema.DiffResult{
+		AddedTriggers: []schema.Trigger{{Name: "trg_new", Table: "orders"}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when AddedTriggers is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForRemovedTrigger(t *testing.T) {
+	result := schema.DiffResult{RemovedTriggers: []string{"trg_old"}}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when RemovedTriggers is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForModifiedTrigger(t *testing.T) {
+	result := schema.DiffResult{
+		ModifiedTriggers: []schema.TriggerDiff{{Name: "trg_sync", EventDiffers: true}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when ModifiedTriggers is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForAddedSequence(t *testing.T) {
+	result := schema.DiffResult{
+		AddedSequences: []schema.Sequence{{Name: "seq_new", StartValue: 1, Increment: 1}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when AddedSequences is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForRemovedSequence(t *testing.T) {
+	result := schema.DiffResult{RemovedSequences: []string{"seq_old"}}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when RemovedSequences is non-empty")
+	}
+}
+
+func TestHasDrift_TrueForModifiedSequence(t *testing.T) {
+	result := schema.DiffResult{
+		ModifiedSequences: []schema.SequenceDiff{{Name: "seq_user_id", IncrementDiffers: true}},
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when ModifiedSequences is non-empty")
+	}
+}
+
+// ── round-trip: JSON marshal → unmarshal preserves values ────────────────────
+
+func TestDiffResult_JSONRoundTrip_ViewDiff(t *testing.T) {
+	original := schema.DiffResult{
+		ModifiedViews: []schema.ViewDiff{
+			{
+				Name:              "v_summary",
+				DefinitionDiffers: true,
+				ProdDefinition:    "SELECT 1",
+				DevDefinition:     "SELECT 2",
+				ProdIsMaterialized: boolPtr(false),
+				DevIsMaterialized:  boolPtr(true),
+			},
+		},
+	}
+
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got schema.DiffResult
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got.ModifiedViews) != 1 {
+		t.Fatalf("expected 1 ModifiedView, got %d", len(got.ModifiedViews))
+	}
+	vd := got.ModifiedViews[0]
+	if vd.Name != "v_summary" {
+		t.Errorf("Name: want %q, got %q", "v_summary", vd.Name)
+	}
+	if !vd.DefinitionDiffers {
+		t.Error("DefinitionDiffers should be true")
+	}
+	if vd.ProdDefinition != "SELECT 1" {
+		t.Errorf("ProdDefinition: want %q, got %q", "SELECT 1", vd.ProdDefinition)
+	}
+	if vd.DevDefinition != "SELECT 2" {
+		t.Errorf("DevDefinition: want %q, got %q", "SELECT 2", vd.DevDefinition)
+	}
+}
+
+func TestDiffResult_JSONRoundTrip_SequenceDiff(t *testing.T) {
+	original := schema.DiffResult{
+		ModifiedSequences: []schema.SequenceDiff{
+			{
+				Name:              "seq_order_id",
+				IncrementDiffers:  true,
+				ProdIncrement:     1,
+				DevIncrement:      5,
+				MaxValueDiffers:   true,
+				ProdMaxValue:      9223372036854775807,
+				DevMaxValue:       1000000,
+				CycleDiffers:      true,
+				ProdCycle:         boolPtr(false),
+				DevCycle:          boolPtr(true),
+			},
+		},
+	}
+
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got schema.DiffResult
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got.ModifiedSequences) != 1 {
+		t.Fatalf("expected 1 ModifiedSequence, got %d", len(got.ModifiedSequences))
+	}
+	sd := got.ModifiedSequences[0]
+	if sd.ProdIncrement != 1 || sd.DevIncrement != 5 {
+		t.Errorf("Increment: want prod=1 dev=5, got prod=%d dev=%d", sd.ProdIncrement, sd.DevIncrement)
+	}
+	if sd.ProdMaxValue != 9223372036854775807 || sd.DevMaxValue != 1000000 {
+		t.Errorf("MaxValue round-trip failed: prod=%d dev=%d", sd.ProdMaxValue, sd.DevMaxValue)
+	}
+	if sd.ProdCycle == nil || *sd.ProdCycle != false {
+		t.Error("ProdCycle should be false")
+	}
+	if sd.DevCycle == nil || *sd.DevCycle != true {
+		t.Error("DevCycle should be true")
+	}
+}

--- a/tests/schema/migrate_options_test.go
+++ b/tests/schema/migrate_options_test.go
@@ -1,0 +1,181 @@
+package schema_test
+
+// Tests for MigrationOptions — new Phase 1 fields (AllowDropView/Routine/Trigger/Sequence)
+// and the behaviour of GenerateMigration when a DiffResult carries the new object types.
+//
+// Phase 1 adds the options and the diff structs only; the migration generator does not yet
+// emit SQL for views/routines/triggers/sequences (that is Phase 2-4 work).  These tests
+// verify:
+//   - new AllowDrop* fields default to false (zero value)
+//   - GenerateMigration does not error when DiffResult contains new object types
+//   - existing table-level output is unaffected when new object types are also present
+//   - AllowDropView/Routine/Trigger/Sequence can be set to true without breaking anything
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/iamvirul/deepdiff-db/internal/schema"
+)
+
+// ── zero-value defaults ───────────────────────────────────────────────────────
+
+func TestMigrationOptions_NewFields_DefaultFalse(t *testing.T) {
+	opts := schema.MigrationOptions{}
+
+	if opts.AllowDropView {
+		t.Error("AllowDropView should default to false")
+	}
+	if opts.AllowDropRoutine {
+		t.Error("AllowDropRoutine should default to false")
+	}
+	if opts.AllowDropTrigger {
+		t.Error("AllowDropTrigger should default to false")
+	}
+	if opts.AllowDropSequence {
+		t.Error("AllowDropSequence should default to false")
+	}
+}
+
+func TestMigrationOptions_NewFields_CanBeSetTrue(t *testing.T) {
+	opts := schema.MigrationOptions{
+		AllowDropView:     true,
+		AllowDropRoutine:  true,
+		AllowDropTrigger:  true,
+		AllowDropSequence: true,
+	}
+
+	if !opts.AllowDropView {
+		t.Error("AllowDropView should be true")
+	}
+	if !opts.AllowDropRoutine {
+		t.Error("AllowDropRoutine should be true")
+	}
+	if !opts.AllowDropTrigger {
+		t.Error("AllowDropTrigger should be true")
+	}
+	if !opts.AllowDropSequence {
+		t.Error("AllowDropSequence should be true")
+	}
+}
+
+// ── GenerateMigration with new object types ───────────────────────────────────
+
+// A DiffResult that contains only view/routine/trigger/sequence changes (no table
+// changes) should produce a valid, empty-body transaction — not an error.
+func TestGenerateMigration_NewObjectTypesOnly_NoError(t *testing.T) {
+	diff := schema.DiffResult{
+		AddedViews:   []schema.View{{Name: "v_active", Definition: "SELECT 1"}},
+		RemovedViews: []string{"v_old"},
+		ModifiedViews: []schema.ViewDiff{
+			{Name: "v_summary", DefinitionDiffers: true},
+		},
+		AddedRoutines:   []schema.Routine{{Name: "fn_calc", Kind: "FUNCTION", Definition: "BEGIN RETURN 1 END"}},
+		RemovedRoutines: []string{"fn_legacy"},
+		ModifiedRoutines: []schema.RoutineDiff{
+			{Name: "fn_price", DefinitionDiffers: true},
+		},
+		AddedTriggers:   []schema.Trigger{{Name: "trg_audit", Table: "orders", Timing: "AFTER", Event: "INSERT"}},
+		RemovedTriggers: []string{"trg_old"},
+		ModifiedTriggers: []schema.TriggerDiff{
+			{Name: "trg_sync", EventDiffers: true},
+		},
+		AddedSequences:   []schema.Sequence{{Name: "seq_order_id", StartValue: 1, Increment: 1}},
+		RemovedSequences: []string{"seq_legacy"},
+		ModifiedSequences: []schema.SequenceDiff{
+			{Name: "seq_user_id", IncrementDiffers: true},
+		},
+	}
+
+	for _, driver := range []string{"sqlite", "mysql", "postgres", "mssql"} {
+		t.Run(driver, func(t *testing.T) {
+			sql, err := schema.GenerateMigration(diff, driver, nil)
+			if err != nil {
+				t.Fatalf("GenerateMigration(%s) unexpected error: %v", driver, err)
+			}
+			if !strings.Contains(sql, "BEGIN;") {
+				t.Errorf("GenerateMigration(%s): expected BEGIN; in output", driver)
+			}
+			if !strings.Contains(sql, "COMMIT;") {
+				t.Errorf("GenerateMigration(%s): expected COMMIT; in output", driver)
+			}
+		})
+	}
+}
+
+// AllowDrop* = true should not cause an error even though the generator has no
+// implementation for these types yet.
+func TestGenerateMigration_AllowDropNewTypes_NoError(t *testing.T) {
+	diff := schema.DiffResult{
+		RemovedViews:    []string{"v_old"},
+		RemovedRoutines: []string{"fn_old"},
+		RemovedTriggers: []string{"trg_old"},
+		RemovedSequences: []string{"seq_old"},
+	}
+
+	opts := &schema.MigrationOptions{
+		AllowDropView:     true,
+		AllowDropRoutine:  true,
+		AllowDropTrigger:  true,
+		AllowDropSequence: true,
+	}
+
+	_, err := schema.GenerateMigration(diff, "sqlite", opts)
+	if err != nil {
+		t.Fatalf("GenerateMigration with AllowDrop* = true returned unexpected error: %v", err)
+	}
+}
+
+// Existing table-level output must be unaffected when new object types are also
+// present in the DiffResult.
+func TestGenerateMigration_TableOutputUnaffectedByNewObjectTypes(t *testing.T) {
+	diff := schema.DiffResult{
+		// A plain table addition
+		AddedTables: []schema.Table{
+			{
+				Name: "orders",
+				Columns: map[string]schema.Column{
+					"id":    {Name: "id", DataType: "INTEGER", IsNullable: false},
+					"total": {Name: "total", DataType: "REAL", IsNullable: true},
+				},
+				PrimaryKey: []string{"id"},
+			},
+		},
+		// Plus new-type noise that should not affect table output
+		AddedViews:      []schema.View{{Name: "v_orders", Definition: "SELECT * FROM orders"}},
+		RemovedRoutines: []string{"fn_old"},
+	}
+
+	sql, err := schema.GenerateMigration(diff, "sqlite", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration() error: %v", err)
+	}
+	if !strings.Contains(sql, "CREATE TABLE") {
+		t.Error("expected CREATE TABLE statement for added table")
+	}
+	if !strings.Contains(sql, "orders") {
+		t.Error("expected table name 'orders' in output")
+	}
+}
+
+// With both table drops and new-type data, AllowDropTable=true still produces
+// an uncommented DROP TABLE statement.
+func TestGenerateMigration_AllowDropTable_WithNewTypesPresent(t *testing.T) {
+	diff := schema.DiffResult{
+		RemovedTables: []string{"legacy_tbl"},
+		RemovedViews:  []string{"v_old"},
+	}
+
+	opts := &schema.MigrationOptions{
+		AllowDropTable:    true,
+		AllowDropView:     true,
+	}
+
+	sql, err := schema.GenerateMigration(diff, "sqlite", opts)
+	if err != nil {
+		t.Fatalf("GenerateMigration() error: %v", err)
+	}
+	if !containsUncommented(sql, "DROP TABLE") {
+		t.Error("expected uncommented DROP TABLE when AllowDropTable=true")
+	}
+}

--- a/tests/schema/migrate_options_test.go
+++ b/tests/schema/migrate_options_test.go
@@ -75,7 +75,7 @@ func TestGenerateMigration_NewObjectTypesOnly_NoError(t *testing.T) {
 		ModifiedRoutines: []schema.RoutineDiff{
 			{Name: "fn_price", DefinitionDiffers: true},
 		},
-		AddedTriggers:   []schema.Trigger{{Name: "trg_audit", Table: "orders", Timing: "AFTER", Event: "INSERT"}},
+		AddedTriggers:   []schema.Trigger{{Name: "trg_audit", Table: "orders", Timing: "AFTER", Event: "INSERT", Definition: "BEGIN INSERT INTO audit_log(action) VALUES('INSERT'); END"}},
 		RemovedTriggers: []string{"trg_old"},
 		ModifiedTriggers: []schema.TriggerDiff{
 			{Name: "trg_sync", EventDiffers: true},


### PR DESCRIPTION
Closes #99

## Summary

- Add `View`, `Routine`, `RoutineParameter`, `Trigger`, `Sequence` structs to `internal/schema/model.go`; extend `Schema` with `Views`, `Routines`, `Triggers`, `Sequences` maps
- Add `ViewDiff`, `RoutineDiff`, `TriggerDiff`, `SequenceDiff` diff structs to `internal/schema/diff.go`; extend `DiffResult` with `Added*/Removed*/Modified*` slices for all four types; update `HasDrift()` to cover new object types
- Extend `IgnoreConfig` in `pkg/config/config.go` with `Views`, `Routines`, `Triggers`, `Sequences` ignore lists
- Extend `MigrationConfig` (`pkg/config/config.go`) and `MigrationOptions` (`internal/schema/migrate.go`) with `AllowDropView`, `AllowDropRoutine`, `AllowDropTrigger`, `AllowDropSequence` safety flags (all default `false`)

## Test plan

- [x] `go build ./...` passes clean
- [x] `go test ./internal/schema/...` passes
- [x] Verify `DiffResult` JSON output includes new `omitempty` slices only when populated
- [x] Confirm `HasDrift()` returns `true` when any new object type differs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema comparison now includes views, routines, triggers, and sequences.
  * Migration options added to control DROP behavior for views, routines, triggers, and sequences.
  * Config supports ignoring specific views, routines, triggers, and sequences.

* **Bug Fixes / Behavior**
  * Drift detection now reports changes for the new object types; JSON output omits empty diff slices.

* **Tests**
  * Added unit tests covering diffs, migration options, and JSON round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->