### PR TITLE
Phase 2: Views Implementation (Introspection, Diff, Migration)

### DIFF
--- a/cmd/deepdiffdb/main.go
+++ b/cmd/deepdiffdb/main.go
@@ -391,11 +391,11 @@ func runFullDiff(args []string) error {
 
 	// Schema diff first
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables)
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables)
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -615,11 +615,11 @@ func runGenPack(args []string) error {
 
 	// Schema diff first
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables)
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables)
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1030,11 +1030,11 @@ func runResolveConflicts(args []string) error {
 	defer devDB.Close()
 
 	// Load schemas for row fetching
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables)
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables)
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1279,11 +1279,11 @@ func runSchemaDiff(args []string) error {
 	defer devDB.Close()
 
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables)
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables)
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1382,11 +1382,11 @@ func runSchemaMigrate(args []string) error {
 
 	// Load schemas
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables)
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables)
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1683,11 +1683,11 @@ func runVersionCommit(args []string) error {
 	defer devDB.Close()
 
 	log.Info("loading schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables)
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables)
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -174,7 +174,7 @@ type DiffResult struct {
 	AddedTables      []Table        `json:"added_tables,omitempty"`    // Full table definitions for CREATE TABLE
 	RemovedTables    []string       `json:"removed_tables,omitempty"`  // Table names for DROP TABLE
 	AddedViews       []View         `json:"added_views,omitempty"`     // Full view definitions for CREATE VIEW
-	RemovedViews     []string       `json:"removed_views,omitempty"`   // View names for DROP VIEW
+	RemovedViews     []View         `json:"removed_views,omitempty"`   // View objects for DROP VIEW/DROP MATERIALIZED VIEW
 	ModifiedViews    []ViewDiff     `json:"modified_views,omitempty"`  // Views present in both but differing
 	AddedRoutines    []Routine      `json:"added_routines,omitempty"`  // Full routine definitions for CREATE
 	RemovedRoutines  []string       `json:"removed_routines,omitempty"`  // Routine names for DROP
@@ -621,10 +621,10 @@ func diffPrimaryKey(prodPK, devPK []string) *PrimaryKeyDiff {
 }
 
 // diffViews compares views between prod and dev.
-// Returns added views (in dev only), removed view names (in prod only), and
+// Returns added views (in dev only), removed views (in prod only), and
 // modified views (in both but with differing definition or materialization).
 // View definitions are normalized before comparison to reduce false positives.
-func diffViews(prodViews, devViews map[string]View) (added []View, removed []string, modified []ViewDiff) {
+func diffViews(prodViews, devViews map[string]View) (added []View, removed []View, modified []ViewDiff) {
 	if prodViews == nil {
 		prodViews = make(map[string]View)
 	}
@@ -651,7 +651,7 @@ func diffViews(prodViews, devViews map[string]View) (added []View, removed []str
 		dv, devOK := devViews[name]
 
 		if prodOK && !devOK {
-			removed = append(removed, name)
+			removed = append(removed, pv)
 			continue
 		}
 		if !prodOK && devOK {

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -254,6 +254,9 @@ func DiffSchemas(prod, dev *Schema) DiffResult {
 		result.Tables = append(result.Tables, td)
 	}
 
+	// Diff views
+	result.AddedViews, result.RemovedViews, result.ModifiedViews = diffViews(prod.Views, dev.Views)
+
 	return result
 }
 
@@ -615,4 +618,72 @@ func diffPrimaryKey(prodPK, devPK []string) *PrimaryKeyDiff {
 		ProdColumns: prodPK,
 		DevColumns:  devPK,
 	}
+}
+
+// diffViews compares views between prod and dev.
+// Returns added views (in dev only), removed view names (in prod only), and
+// modified views (in both but with differing definition or materialization).
+// View definitions are normalized before comparison to reduce false positives.
+func diffViews(prodViews, devViews map[string]View) (added []View, removed []string, modified []ViewDiff) {
+	if prodViews == nil {
+		prodViews = make(map[string]View)
+	}
+	if devViews == nil {
+		devViews = make(map[string]View)
+	}
+
+	seen := make(map[string]struct{})
+	for name := range prodViews {
+		seen[name] = struct{}{}
+	}
+	for name := range devViews {
+		seen[name] = struct{}{}
+	}
+
+	var names []string
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		pv, prodOK := prodViews[name]
+		dv, devOK := devViews[name]
+
+		if prodOK && !devOK {
+			removed = append(removed, name)
+			continue
+		}
+		if !prodOK && devOK {
+			added = append(added, dv)
+			continue
+		}
+
+		// Both exist — check for differences
+		vd := ViewDiff{Name: name}
+		hasDiff := false
+
+		if normalizeViewDefinition(pv.Definition) != normalizeViewDefinition(dv.Definition) {
+			vd.DefinitionDiffers = true
+			vd.ProdDefinition = pv.Definition
+			vd.DevDefinition = dv.Definition
+			hasDiff = true
+		}
+		if pv.IsMaterialized != dv.IsMaterialized {
+			vd.IsMaterializedDiffers = true
+			vd.ProdIsMaterialized = &pv.IsMaterialized
+			vd.DevIsMaterialized = &dv.IsMaterialized
+			hasDiff = true
+		}
+		if hasDiff {
+			modified = append(modified, vd)
+		}
+	}
+	return
+}
+
+// normalizeViewDefinition normalizes a view definition for comparison.
+// Trims whitespace, collapses runs of whitespace to a single space, and lowercases.
+func normalizeViewDefinition(def string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(def)), " "))
 }

--- a/internal/schema/introspect.go
+++ b/internal/schema/introspect.go
@@ -393,9 +393,8 @@ func loadSQLiteViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[stri
 			// Extract only the query body after "AS"
 			sqlText := sqlDef.String
 			// Find the first case-insensitive "AS" token
-			asIdx := -1
 			lowerSQL := strings.ToLower(sqlText)
-			asIdx = strings.Index(lowerSQL, " as ")
+			asIdx := strings.Index(lowerSQL, " as ")
 			if asIdx != -1 {
 				// Take everything after " AS "
 				definition = strings.TrimSpace(sqlText[asIdx+4:])

--- a/internal/schema/introspect.go
+++ b/internal/schema/introspect.go
@@ -11,11 +11,16 @@ import (
 	"github.com/iamvirul/deepdiff-db/pkg/progress"
 )
 
+// LoadSchemaOptions provides optional configuration for LoadSchema.
+type LoadSchemaOptions struct {
+	IgnoreViews []string // View names to exclude (case-insensitive)
+}
+
 // LoadSchema loads table and column metadata for the specified SQL driver into a Schema,
 // building Table entries with Columns and ordered PrimaryKey values and respecting the provided ignoreTables (case-insensitive).
 // Supported drivers: "mysql", "postgres"/"postgresql", and "sqlite"; the database parameter is used for MySQL queries.
 // Returns an error if the driver is unsupported or if any database query or row scanning fails.
-func LoadSchema(ctx context.Context, db *sql.DB, driver string, database string, ignoreTables []string) (*Schema, error) {
+func LoadSchema(ctx context.Context, db *sql.DB, driver string, database string, ignoreTables []string, opts ...LoadSchemaOptions) (*Schema, error) {
 	// Get logger and progress manager from context
 	log := logger.FromContext(ctx).WithDatabase(driver, database)
 	progressMgr := progress.FromContext(ctx)
@@ -228,6 +233,16 @@ func LoadSchema(ctx context.Context, db *sql.DB, driver string, database string,
 		return nil, fmt.Errorf("load foreign keys: %w", err)
 	}
 
+	// Load views
+	var ignoreViews []string
+	if len(opts) > 0 {
+		ignoreViews = opts[0].IgnoreViews
+	}
+	log.Debug("loading views")
+	if err := loadViews(ctx, db, driver, database, s, ignoreViews); err != nil {
+		return nil, fmt.Errorf("load views: %w", err)
+	}
+
 	// Calculate total columns
 	totalColumns := 0
 	for _, tbl := range s.Tables {
@@ -239,6 +254,145 @@ func LoadSchema(ctx context.Context, db *sql.DB, driver string, database string,
 		"columns", totalColumns)
 
 	return s, nil
+}
+
+// loadViews queries the database for view metadata and populates the Views map in the schema.
+// It dispatches to driver-specific view loading functions. MSSQL and Oracle are no-ops in Phase 2.
+func loadViews(ctx context.Context, db *sql.DB, driver string, database string, s *Schema, ignoreViews []string) error {
+	ignore := make(map[string]struct{}, len(ignoreViews))
+	for _, v := range ignoreViews {
+		ignore[strings.ToLower(v)] = struct{}{}
+	}
+	switch driver {
+	case "mysql":
+		return loadMySQLViews(ctx, db, database, s, ignore)
+	case "postgres", "postgresql":
+		return loadPostgreSQLViews(ctx, db, s, ignore)
+	case "sqlite":
+		return loadSQLiteViews(ctx, db, s, ignore)
+	case "mssql", "oracle":
+		return nil // not implemented in Phase 2
+	default:
+		return fmt.Errorf("view introspection unsupported for driver: %s", driver)
+	}
+}
+
+// loadMySQLViews queries information_schema.views to load view metadata.
+func loadMySQLViews(ctx context.Context, db *sql.DB, database string, s *Schema, ignore map[string]struct{}) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT table_name, view_definition
+		FROM information_schema.views
+		WHERE table_schema = ?
+		ORDER BY table_name
+	`, database)
+	if err != nil {
+		return fmt.Errorf("mysql views: %w", err)
+	}
+	defer rows.Close()
+
+	if s.Views == nil {
+		s.Views = make(map[string]View)
+	}
+	for rows.Next() {
+		var name, definition string
+		if err := rows.Scan(&name, &definition); err != nil {
+			return fmt.Errorf("mysql views scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		s.Views[name] = View{Name: name, Definition: definition, IsMaterialized: false}
+	}
+	return rows.Err()
+}
+
+// loadPostgreSQLViews queries pg_views and pg_matviews to load all views (including materialized).
+func loadPostgreSQLViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[string]struct{}) error {
+	if s.Views == nil {
+		s.Views = make(map[string]View)
+	}
+
+	// Regular views
+	rows, err := db.QueryContext(ctx, `
+		SELECT viewname, definition
+		FROM pg_views
+		WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY viewname
+	`)
+	if err != nil {
+		return fmt.Errorf("postgresql views: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, definition string
+		if err := rows.Scan(&name, &definition); err != nil {
+			return fmt.Errorf("postgresql views scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		s.Views[name] = View{Name: name, Definition: strings.TrimSpace(definition), IsMaterialized: false}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// Materialized views
+	matRows, err := db.QueryContext(ctx, `
+		SELECT matviewname, definition
+		FROM pg_matviews
+		WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY matviewname
+	`)
+	if err != nil {
+		return fmt.Errorf("postgresql materialized views: %w", err)
+	}
+	defer matRows.Close()
+	for matRows.Next() {
+		var name, definition string
+		if err := matRows.Scan(&name, &definition); err != nil {
+			return fmt.Errorf("postgresql materialized views scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		s.Views[name] = View{Name: name, Definition: strings.TrimSpace(definition), IsMaterialized: true}
+	}
+	return matRows.Err()
+}
+
+// loadSQLiteViews queries sqlite_master to load view metadata.
+func loadSQLiteViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[string]struct{}) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT name, sql
+		FROM sqlite_master
+		WHERE type = 'view'
+		ORDER BY name
+	`)
+	if err != nil {
+		return fmt.Errorf("sqlite views: %w", err)
+	}
+	defer rows.Close()
+
+	if s.Views == nil {
+		s.Views = make(map[string]View)
+	}
+	for rows.Next() {
+		var name string
+		var sqlDef sql.NullString
+		if err := rows.Scan(&name, &sqlDef); err != nil {
+			return fmt.Errorf("sqlite views scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		definition := ""
+		if sqlDef.Valid {
+			definition = sqlDef.String
+		}
+		s.Views[name] = View{Name: name, Definition: definition, IsMaterialized: false}
+	}
+	return rows.Err()
 }
 
 // scanColumns reads column metadata from rows and populates s.Tables with Table and Column entries.

--- a/internal/schema/introspect.go
+++ b/internal/schema/introspect.go
@@ -314,9 +314,9 @@ func loadPostgreSQLViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[
 
 	// Regular views
 	rows, err := db.QueryContext(ctx, `
-		SELECT viewname, definition
+		SELECT schemaname, viewname, definition
 		FROM pg_views
-		WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+		WHERE schemaname = current_schema()
 		ORDER BY viewname
 	`)
 	if err != nil {
@@ -324,14 +324,15 @@ func loadPostgreSQLViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var name, definition string
-		if err := rows.Scan(&name, &definition); err != nil {
+		var schema, name, definition string
+		if err := rows.Scan(&schema, &name, &definition); err != nil {
 			return fmt.Errorf("postgresql views scan: %w", err)
 		}
 		if _, skip := ignore[strings.ToLower(name)]; skip {
 			continue
 		}
-		s.Views[name] = View{Name: name, Definition: strings.TrimSpace(definition), IsMaterialized: false}
+		qualifiedName := fmt.Sprintf("%s.%s", schema, name)
+		s.Views[qualifiedName] = View{Name: qualifiedName, Definition: strings.TrimSpace(definition), IsMaterialized: false}
 	}
 	if err := rows.Err(); err != nil {
 		return err
@@ -339,9 +340,9 @@ func loadPostgreSQLViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[
 
 	// Materialized views
 	matRows, err := db.QueryContext(ctx, `
-		SELECT matviewname, definition
+		SELECT schemaname, matviewname, definition
 		FROM pg_matviews
-		WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+		WHERE schemaname = current_schema()
 		ORDER BY matviewname
 	`)
 	if err != nil {
@@ -349,14 +350,15 @@ func loadPostgreSQLViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[
 	}
 	defer matRows.Close()
 	for matRows.Next() {
-		var name, definition string
-		if err := matRows.Scan(&name, &definition); err != nil {
+		var schema, name, definition string
+		if err := matRows.Scan(&schema, &name, &definition); err != nil {
 			return fmt.Errorf("postgresql materialized views scan: %w", err)
 		}
 		if _, skip := ignore[strings.ToLower(name)]; skip {
 			continue
 		}
-		s.Views[name] = View{Name: name, Definition: strings.TrimSpace(definition), IsMaterialized: true}
+		qualifiedName := fmt.Sprintf("%s.%s", schema, name)
+		s.Views[qualifiedName] = View{Name: qualifiedName, Definition: strings.TrimSpace(definition), IsMaterialized: true}
 	}
 	return matRows.Err()
 }
@@ -388,7 +390,22 @@ func loadSQLiteViews(ctx context.Context, db *sql.DB, s *Schema, ignore map[stri
 		}
 		definition := ""
 		if sqlDef.Valid {
-			definition = sqlDef.String
+			// Extract only the query body after "AS"
+			sqlText := sqlDef.String
+			// Find the first case-insensitive "AS" token
+			asIdx := -1
+			lowerSQL := strings.ToLower(sqlText)
+			asIdx = strings.Index(lowerSQL, " as ")
+			if asIdx != -1 {
+				// Take everything after " AS "
+				definition = strings.TrimSpace(sqlText[asIdx+4:])
+				// Remove trailing semicolon if present
+				definition = strings.TrimSuffix(definition, ";")
+				definition = strings.TrimSpace(definition)
+			} else {
+				// Fallback: if no "AS" found, use the whole definition
+				definition = sqlText
+			}
 		}
 		s.Views[name] = View{Name: name, Definition: definition, IsMaterialized: false}
 	}

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -340,14 +340,23 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 					// These drivers don't support materialized views - emit manual review comment
 					stmts = append(stmts, fmt.Sprintf("-- Manual review required to determine materialized view support for %s", driver))
 					stmts = append(stmts, "-- Materialized view requested but not supported; creating standard view instead:")
-					createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+					if driver == "sqlite" {
+						createStmt = fmt.Sprintf("CREATE VIEW IF NOT EXISTS %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+					} else {
+						createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+					}
 				default:
 					// Unknown driver - emit manual review comment
 					stmts = append(stmts, fmt.Sprintf("-- Manual review required to determine materialized view support for %s", driver))
 					createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
 				}
 			} else {
-				createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+				switch driver {
+				case "sqlite":
+					createStmt = fmt.Sprintf("CREATE VIEW IF NOT EXISTS %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+				default:
+					createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(view.Name, driver), view.Definition)
+				}
 			}
 			stmts = append(stmts, createStmt)
 		}
@@ -357,14 +366,27 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 	// Process modified views
 	if len(diff.ModifiedViews) > 0 {
 		stmts = append(stmts, "-- MODIFIED VIEWS (differ between prod and dev)")
-		stmts = append(stmts, "-- NOTE: To modify a view, drop and recreate it. Manual review required.")
-		for _, viewDiff := range diff.ModifiedViews {
-			stmts = append(stmts, fmt.Sprintf("-- View %s differs between prod and dev", viewDiff.Name))
-			if viewDiff.DefinitionDiffers {
-				stmts = append(stmts, "--   Definition differs")
+		for _, vd := range diff.ModifiedViews {
+			stmts = append(stmts, fmt.Sprintf("-- View: %s", vd.Name))
+			if vd.IsMaterializedDiffers && vd.ProdIsMaterialized != nil && vd.DevIsMaterialized != nil {
+				stmts = append(stmts, fmt.Sprintf("--   IsMaterialized: prod=%v dev=%v (manual review required)", *vd.ProdIsMaterialized, *vd.DevIsMaterialized))
 			}
-			if viewDiff.IsMaterializedDiffers {
-				stmts = append(stmts, fmt.Sprintf("--   IsMaterialized: prod=%v dev=%v", *viewDiff.ProdIsMaterialized, *viewDiff.DevIsMaterialized))
+			if vd.DefinitionDiffers && vd.DevDefinition != "" {
+				switch driver {
+				case "postgres", "postgresql":
+					// PostgreSQL supports CREATE OR REPLACE VIEW
+					stmts = append(stmts, fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition))
+				default:
+					// MySQL and SQLite require DROP + CREATE
+					dropStmt := fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(vd.Name, driver))
+					if !opts.AllowDropView {
+						dropStmt = "-- " + dropStmt
+					}
+					stmts = append(stmts, dropStmt)
+					stmts = append(stmts, fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition))
+				}
+			} else if vd.DefinitionDiffers {
+				stmts = append(stmts, fmt.Sprintf("-- View %s definition differs but dev definition is empty; manual review required", vd.Name))
 			}
 		}
 		stmts = append(stmts, "")

--- a/internal/schema/migrate.go
+++ b/internal/schema/migrate.go
@@ -315,8 +315,13 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 		if opts.ConfirmDestructive {
 			stmts = append(stmts, "-- IMPORTANT: Review carefully before executing!")
 		}
-		for _, viewName := range diff.RemovedViews {
-			dropStmt := fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(viewName, driver))
+		for _, view := range diff.RemovedViews {
+			var dropStmt string
+			if view.IsMaterialized {
+				dropStmt = fmt.Sprintf("DROP MATERIALIZED VIEW %s;", quoteIdentifier(view.Name, driver))
+			} else {
+				dropStmt = fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(view.Name, driver))
+			}
 			if !opts.AllowDropView {
 				dropStmt = "-- " + dropStmt
 			}
@@ -368,22 +373,94 @@ func GenerateMigrationWithSchemas(diff DiffResult, driver string, opts *Migratio
 		stmts = append(stmts, "-- MODIFIED VIEWS (differ between prod and dev)")
 		for _, vd := range diff.ModifiedViews {
 			stmts = append(stmts, fmt.Sprintf("-- View: %s", vd.Name))
+
+			// Check if materialization differs
 			if vd.IsMaterializedDiffers && vd.ProdIsMaterialized != nil && vd.DevIsMaterialized != nil {
-				stmts = append(stmts, fmt.Sprintf("--   IsMaterialized: prod=%v dev=%v (manual review required)", *vd.ProdIsMaterialized, *vd.DevIsMaterialized))
-			}
-			if vd.DefinitionDiffers && vd.DevDefinition != "" {
-				switch driver {
-				case "postgres", "postgresql":
-					// PostgreSQL supports CREATE OR REPLACE VIEW
-					stmts = append(stmts, fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition))
-				default:
-					// MySQL and SQLite require DROP + CREATE
-					dropStmt := fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(vd.Name, driver))
-					if !opts.AllowDropView {
-						dropStmt = "-- " + dropStmt
+				stmts = append(stmts, fmt.Sprintf("--   IsMaterialized: prod=%v dev=%v", *vd.ProdIsMaterialized, *vd.DevIsMaterialized))
+
+				// When materialization differs, we need to DROP the old object and CREATE the new one
+				var dropStmt string
+				if *vd.ProdIsMaterialized {
+					dropStmt = fmt.Sprintf("DROP MATERIALIZED VIEW %s;", quoteIdentifier(vd.Name, driver))
+				} else {
+					dropStmt = fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(vd.Name, driver))
+				}
+				if !opts.AllowDropView {
+					dropStmt = "-- " + dropStmt
+				}
+				stmts = append(stmts, dropStmt)
+
+				// Create the new object
+				if vd.DevDefinition != "" {
+					var createStmt string
+					if *vd.DevIsMaterialized {
+						// Creating materialized view
+						switch driver {
+						case "postgres", "postgresql":
+							createStmt = fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition)
+						default:
+							stmts = append(stmts, fmt.Sprintf("-- Manual review required: %s does not support materialized views", driver))
+							createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition)
+						}
+					} else {
+						createStmt = fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition)
 					}
-					stmts = append(stmts, dropStmt)
-					stmts = append(stmts, fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition))
+					if !opts.AllowDropView {
+						createStmt = "-- " + createStmt
+					}
+					stmts = append(stmts, createStmt)
+				}
+			} else if vd.DefinitionDiffers && vd.DevDefinition != "" {
+				// Definition differs but materialization is the same
+				devIsMaterialized := vd.DevIsMaterialized != nil && *vd.DevIsMaterialized
+
+				if devIsMaterialized {
+					// Handle materialized view replacement
+					switch driver {
+					case "postgres", "postgresql":
+						// PostgreSQL does not support CREATE OR REPLACE for materialized views
+						dropStmt := fmt.Sprintf("DROP MATERIALIZED VIEW %s;", quoteIdentifier(vd.Name, driver))
+						if !opts.AllowDropView {
+							dropStmt = "-- " + dropStmt
+						}
+						stmts = append(stmts, dropStmt)
+						createStmt := fmt.Sprintf("CREATE MATERIALIZED VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition)
+						if !opts.AllowDropView {
+							createStmt = "-- " + createStmt
+						}
+						stmts = append(stmts, createStmt)
+					default:
+						stmts = append(stmts, fmt.Sprintf("-- Manual review required: %s does not support materialized views", driver))
+						dropStmt := fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(vd.Name, driver))
+						if !opts.AllowDropView {
+							dropStmt = "-- " + dropStmt
+						}
+						stmts = append(stmts, dropStmt)
+						createStmt := fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition)
+						if !opts.AllowDropView {
+							createStmt = "-- " + createStmt
+						}
+						stmts = append(stmts, createStmt)
+					}
+				} else {
+					// Handle regular view replacement
+					switch driver {
+					case "postgres", "postgresql":
+						// PostgreSQL supports CREATE OR REPLACE VIEW
+						stmts = append(stmts, fmt.Sprintf("CREATE OR REPLACE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition))
+					default:
+						// MySQL and SQLite require DROP + CREATE
+						dropStmt := fmt.Sprintf("DROP VIEW %s;", quoteIdentifier(vd.Name, driver))
+						if !opts.AllowDropView {
+							dropStmt = "-- " + dropStmt
+						}
+						stmts = append(stmts, dropStmt)
+						createStmt := fmt.Sprintf("CREATE VIEW %s AS %s;", quoteIdentifier(vd.Name, driver), vd.DevDefinition)
+						if !opts.AllowDropView {
+							createStmt = "-- " + createStmt
+						}
+						stmts = append(stmts, createStmt)
+					}
 				}
 			} else if vd.DefinitionDiffers {
 				stmts = append(stmts, fmt.Sprintf("-- View %s definition differs but dev definition is empty; manual review required", vd.Name))

--- a/tests/schema/diff_objects_test.go
+++ b/tests/schema/diff_objects_test.go
@@ -49,7 +49,7 @@ func TestDiffResult_OmitemptySlices_PresentWhenPopulated(t *testing.T) {
 		AddedViews: []schema.View{
 			{Name: "v_active", Definition: "SELECT 1", IsMaterialized: false},
 		},
-		RemovedViews: []string{"v_old"},
+		RemovedViews: []schema.View{{Name: "v_old"}},
 		ModifiedViews: []schema.ViewDiff{
 			{Name: "v_summary", DefinitionDiffers: true, ProdDefinition: "SELECT 1", DevDefinition: "SELECT 2"},
 		},
@@ -114,7 +114,7 @@ func TestHasDrift_TrueForAddedView(t *testing.T) {
 }
 
 func TestHasDrift_TrueForRemovedView(t *testing.T) {
-	result := schema.DiffResult{RemovedViews: []string{"v_old"}}
+	result := schema.DiffResult{RemovedViews: []schema.View{{Name: "v_old"}}}
 	if !result.HasDrift() {
 		t.Error("HasDrift() should be true when RemovedViews is non-empty")
 	}

--- a/tests/schema/migrate_options_test.go
+++ b/tests/schema/migrate_options_test.go
@@ -66,7 +66,7 @@ func TestMigrationOptions_NewFields_CanBeSetTrue(t *testing.T) {
 func TestGenerateMigration_NewObjectTypesOnly_NoError(t *testing.T) {
 	diff := schema.DiffResult{
 		AddedViews:   []schema.View{{Name: "v_active", Definition: "SELECT 1"}},
-		RemovedViews: []string{"v_old"},
+		RemovedViews: []schema.View{{Name: "v_old"}},
 		ModifiedViews: []schema.ViewDiff{
 			{Name: "v_summary", DefinitionDiffers: true},
 		},
@@ -107,7 +107,7 @@ func TestGenerateMigration_NewObjectTypesOnly_NoError(t *testing.T) {
 // implementation for these types yet.
 func TestGenerateMigration_AllowDropNewTypes_NoError(t *testing.T) {
 	diff := schema.DiffResult{
-		RemovedViews:    []string{"v_old"},
+		RemovedViews:    []schema.View{{Name: "v_old"}},
 		RemovedRoutines: []string{"fn_old"},
 		RemovedTriggers: []string{"trg_old"},
 		RemovedSequences: []string{"seq_old"},
@@ -163,7 +163,7 @@ func TestGenerateMigration_TableOutputUnaffectedByNewObjectTypes(t *testing.T) {
 func TestGenerateMigration_AllowDropTable_WithNewTypesPresent(t *testing.T) {
 	diff := schema.DiffResult{
 		RemovedTables: []string{"legacy_tbl"},
-		RemovedViews:  []string{"v_old"},
+		RemovedViews:  []schema.View{{Name: "v_old"}},
 	}
 
 	opts := &schema.MigrationOptions{

--- a/tests/schema/views_test.go
+++ b/tests/schema/views_test.go
@@ -1,0 +1,482 @@
+package schema_test
+
+// Tests for Phase 2: Views — diffViews logic, migration generation, and SQLite introspection.
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/iamvirul/deepdiff-db/internal/schema"
+)
+
+// ── diffViews unit tests ──────────────────────────────────────────────────────
+
+func TestDiffViews_EmptyBothSides(t *testing.T) {
+	result := schema.DiffSchemas(
+		&schema.Schema{Tables: map[string]schema.Table{}, Views: map[string]schema.View{}},
+		&schema.Schema{Tables: map[string]schema.Table{}, Views: map[string]schema.View{}},
+	)
+	if len(result.AddedViews) != 0 || len(result.RemovedViews) != 0 || len(result.ModifiedViews) != 0 {
+		t.Errorf("expected no view diffs, got added=%d removed=%d modified=%d",
+			len(result.AddedViews), len(result.RemovedViews), len(result.ModifiedViews))
+	}
+}
+
+func TestDiffViews_AddedView(t *testing.T) {
+	prod := &schema.Schema{Tables: map[string]schema.Table{}, Views: map[string]schema.View{}}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_active": {Name: "v_active", Definition: "SELECT id FROM users WHERE active = 1"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+
+	if len(result.AddedViews) != 1 {
+		t.Fatalf("expected 1 AddedView, got %d", len(result.AddedViews))
+	}
+	if result.AddedViews[0].Name != "v_active" {
+		t.Errorf("AddedViews[0].Name = %q, want %q", result.AddedViews[0].Name, "v_active")
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when views added")
+	}
+}
+
+func TestDiffViews_RemovedView(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_legacy": {Name: "v_legacy", Definition: "SELECT * FROM old_table"},
+		},
+	}
+	dev := &schema.Schema{Tables: map[string]schema.Table{}, Views: map[string]schema.View{}}
+	result := schema.DiffSchemas(prod, dev)
+
+	if len(result.RemovedViews) != 1 || result.RemovedViews[0] != "v_legacy" {
+		t.Errorf("expected RemovedViews=[v_legacy], got %v", result.RemovedViews)
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true when views removed")
+	}
+}
+
+func TestDiffViews_IdenticalViews_NoDiff(t *testing.T) {
+	def := "SELECT id, name FROM users WHERE active = 1"
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views:  map[string]schema.View{"v_active": {Name: "v_active", Definition: def}},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views:  map[string]schema.View{"v_active": {Name: "v_active", Definition: def}},
+	}
+	result := schema.DiffSchemas(prod, dev)
+
+	if len(result.ModifiedViews) != 0 {
+		t.Errorf("expected no modified views for identical definitions, got %v", result.ModifiedViews)
+	}
+}
+
+func TestDiffViews_NormalizationIgnoresWhitespace(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_users": {Name: "v_users", Definition: "SELECT  id  FROM   users"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_users": {Name: "v_users", Definition: "select id from users"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+
+	if len(result.ModifiedViews) != 0 {
+		t.Errorf("expected no diff after normalization, got modified=%v", result.ModifiedViews)
+	}
+}
+
+func TestDiffViews_DefinitionDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_summary": {Name: "v_summary", Definition: "SELECT COUNT(*) FROM orders"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_summary": {Name: "v_summary", Definition: "SELECT COUNT(*), SUM(total) FROM orders"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+
+	if len(result.ModifiedViews) != 1 {
+		t.Fatalf("expected 1 ModifiedView, got %d", len(result.ModifiedViews))
+	}
+	vd := result.ModifiedViews[0]
+	if !vd.DefinitionDiffers {
+		t.Error("DefinitionDiffers should be true")
+	}
+	if vd.ProdDefinition != "SELECT COUNT(*) FROM orders" {
+		t.Errorf("ProdDefinition: got %q", vd.ProdDefinition)
+	}
+	if vd.DevDefinition != "SELECT COUNT(*), SUM(total) FROM orders" {
+		t.Errorf("DevDefinition: got %q", vd.DevDefinition)
+	}
+}
+
+func TestDiffViews_MaterializedDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_mat": {Name: "v_mat", Definition: "SELECT id FROM users", IsMaterialized: false},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_mat": {Name: "v_mat", Definition: "SELECT id FROM users", IsMaterialized: true},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+
+	if len(result.ModifiedViews) != 1 {
+		t.Fatalf("expected 1 ModifiedView, got %d", len(result.ModifiedViews))
+	}
+	vd := result.ModifiedViews[0]
+	if !vd.IsMaterializedDiffers {
+		t.Error("IsMaterializedDiffers should be true")
+	}
+	if vd.ProdIsMaterialized == nil || *vd.ProdIsMaterialized != false {
+		t.Error("ProdIsMaterialized should be false")
+	}
+	if vd.DevIsMaterialized == nil || *vd.DevIsMaterialized != true {
+		t.Error("DevIsMaterialized should be true")
+	}
+}
+
+func TestDiffViews_DeterministicOrder(t *testing.T) {
+	prod := &schema.Schema{Tables: map[string]schema.Table{}, Views: map[string]schema.View{}}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Views: map[string]schema.View{
+			"v_z": {Name: "v_z", Definition: "SELECT 3"},
+			"v_a": {Name: "v_a", Definition: "SELECT 1"},
+			"v_m": {Name: "v_m", Definition: "SELECT 2"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+
+	if len(result.AddedViews) != 3 {
+		t.Fatalf("expected 3 AddedViews, got %d", len(result.AddedViews))
+	}
+	names := []string{result.AddedViews[0].Name, result.AddedViews[1].Name, result.AddedViews[2].Name}
+	if names[0] != "v_a" || names[1] != "v_m" || names[2] != "v_z" {
+		t.Errorf("AddedViews not sorted alphabetically: %v", names)
+	}
+}
+
+// ── Migration generation for views ───────────────────────────────────────────
+
+func TestGenerateMigration_AddView_SQLite(t *testing.T) {
+	diff := schema.DiffResult{
+		AddedViews: []schema.View{
+			{Name: "v_active", Definition: "SELECT id FROM users WHERE active = 1"},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "sqlite", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "CREATE VIEW IF NOT EXISTS") {
+		t.Errorf("SQLite should use CREATE VIEW IF NOT EXISTS, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "v_active") {
+		t.Errorf("expected view name in output")
+	}
+}
+
+func TestGenerateMigration_AddView_MySQL(t *testing.T) {
+	diff := schema.DiffResult{
+		AddedViews: []schema.View{
+			{Name: "v_active", Definition: "SELECT id FROM users WHERE active = 1"},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "CREATE VIEW") {
+		t.Errorf("expected CREATE VIEW in MySQL output")
+	}
+	// MySQL must NOT use IF NOT EXISTS
+	if strings.Contains(sql, "IF NOT EXISTS") {
+		t.Errorf("MySQL should not use IF NOT EXISTS for views")
+	}
+}
+
+func TestGenerateMigration_AddView_PostgreSQL_Materialized(t *testing.T) {
+	diff := schema.DiffResult{
+		AddedViews: []schema.View{
+			{Name: "v_mat", Definition: "SELECT id FROM users", IsMaterialized: true},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "postgres", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "CREATE MATERIALIZED VIEW") {
+		t.Errorf("PostgreSQL should emit CREATE MATERIALIZED VIEW, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_DropView_CommentedByDefault(t *testing.T) {
+	diff := schema.DiffResult{RemovedViews: []string{"v_old"}}
+	sql, err := schema.GenerateMigration(diff, "sqlite", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if containsUncommented(sql, "DROP VIEW") {
+		t.Error("DROP VIEW should be commented out by default")
+	}
+	if !strings.Contains(sql, "DROP VIEW") {
+		t.Error("DROP VIEW should appear (commented) in output")
+	}
+}
+
+func TestGenerateMigration_DropView_UncommentedWhenAllowed(t *testing.T) {
+	diff := schema.DiffResult{RemovedViews: []string{"v_old"}}
+	opts := &schema.MigrationOptions{AllowDropView: true}
+	sql, err := schema.GenerateMigration(diff, "sqlite", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !containsUncommented(sql, "DROP VIEW") {
+		t.Error("DROP VIEW should be uncommented when AllowDropView=true")
+	}
+}
+
+func TestGenerateMigration_ModifiedView_PostgreSQL_CreateOrReplace(t *testing.T) {
+	diff := schema.DiffResult{
+		ModifiedViews: []schema.ViewDiff{
+			{
+				Name:              "v_summary",
+				DefinitionDiffers: true,
+				ProdDefinition:    "SELECT COUNT(*) FROM orders",
+				DevDefinition:     "SELECT COUNT(*), SUM(total) FROM orders",
+			},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "postgres", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "CREATE OR REPLACE VIEW") {
+		t.Errorf("PostgreSQL modified view should use CREATE OR REPLACE VIEW, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_ModifiedView_MySQL_DropCreate(t *testing.T) {
+	diff := schema.DiffResult{
+		ModifiedViews: []schema.ViewDiff{
+			{
+				Name:              "v_summary",
+				DefinitionDiffers: true,
+				ProdDefinition:    "SELECT COUNT(*) FROM orders",
+				DevDefinition:     "SELECT COUNT(*), SUM(total) FROM orders",
+			},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "DROP VIEW") {
+		t.Errorf("MySQL modified view should include DROP VIEW")
+	}
+	if !strings.Contains(sql, "CREATE VIEW") {
+		t.Errorf("MySQL modified view should include CREATE VIEW")
+	}
+}
+
+// ── SQLite introspection (real DB) ────────────────────────────────────────────
+
+func openSQLiteDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite3: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestLoadSchema_SQLite_LoadsViews(t *testing.T) {
+	db := openSQLiteDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, active INTEGER)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE VIEW v_active AS SELECT id, name FROM users WHERE active = 1`)
+	if err != nil {
+		t.Fatalf("create view: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE VIEW v_all AS SELECT id, name FROM users`)
+	if err != nil {
+		t.Fatalf("create view v_all: %v", err)
+	}
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	if len(s.Views) != 2 {
+		t.Errorf("expected 2 views, got %d: %v", len(s.Views), s.Views)
+	}
+	if _, ok := s.Views["v_active"]; !ok {
+		t.Error("v_active not found in Views")
+	}
+	if _, ok := s.Views["v_all"]; !ok {
+		t.Error("v_all not found in Views")
+	}
+	if s.Views["v_active"].IsMaterialized {
+		t.Error("SQLite views should never be materialized")
+	}
+}
+
+func TestLoadSchema_SQLite_IgnoreViews(t *testing.T) {
+	db := openSQLiteDB(t)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`)
+	_, _ = db.ExecContext(ctx, `CREATE VIEW v_keep AS SELECT id FROM users`)
+	_, _ = db.ExecContext(ctx, `CREATE VIEW v_ignore AS SELECT name FROM users`)
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil,
+		schema.LoadSchemaOptions{IgnoreViews: []string{"v_ignore"}})
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	if _, ok := s.Views["v_ignore"]; ok {
+		t.Error("v_ignore should have been excluded by IgnoreViews")
+	}
+	if _, ok := s.Views["v_keep"]; !ok {
+		t.Error("v_keep should still be present")
+	}
+}
+
+func TestLoadSchema_SQLite_IgnoreViews_CaseInsensitive(t *testing.T) {
+	db := openSQLiteDB(t)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+	_, _ = db.ExecContext(ctx, `CREATE VIEW V_Secret AS SELECT id FROM users`)
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil,
+		schema.LoadSchemaOptions{IgnoreViews: []string{"v_secret"}}) // lowercase
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	if _, ok := s.Views["V_Secret"]; ok {
+		t.Error("V_Secret should be excluded by case-insensitive ignore")
+	}
+}
+
+func TestLoadSchema_SQLite_NoViews(t *testing.T) {
+	db := openSQLiteDB(t)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, `CREATE TABLE items (id INTEGER PRIMARY KEY)`)
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	if len(s.Views) != 0 {
+		t.Errorf("expected 0 views when none created, got %d", len(s.Views))
+	}
+}
+
+func TestLoadSchema_SQLite_ViewDefinitionStored(t *testing.T) {
+	db := openSQLiteDB(t)
+	ctx := context.Background()
+
+	_, _ = db.ExecContext(ctx, `CREATE TABLE orders (id INTEGER PRIMARY KEY, total REAL)`)
+	_, _ = db.ExecContext(ctx, `CREATE VIEW v_orders AS SELECT id, total FROM orders WHERE total > 0`)
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	v, ok := s.Views["v_orders"]
+	if !ok {
+		t.Fatal("v_orders not found")
+	}
+	if !strings.Contains(strings.ToLower(v.Definition), "select") {
+		t.Errorf("view definition should contain SELECT, got: %q", v.Definition)
+	}
+}
+
+// ── Full diff pipeline: introspect → diff → migrate ─────────────────��────────
+
+func TestViewPipeline_SQLite_EndToEnd(t *testing.T) {
+	ctx := context.Background()
+
+	// Prod DB: has v_active
+	prodDB := openSQLiteDB(t)
+	_, _ = prodDB.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, active INTEGER)`)
+	_, _ = prodDB.ExecContext(ctx, `CREATE VIEW v_active AS SELECT id, name FROM users WHERE active = 1`)
+
+	// Dev DB: v_active changed definition, plus new v_all
+	devDB := openSQLiteDB(t)
+	_, _ = devDB.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, active INTEGER)`)
+	_, _ = devDB.ExecContext(ctx, `CREATE VIEW v_active AS SELECT id, name, active FROM users WHERE active = 1`)
+	_, _ = devDB.ExecContext(ctx, `CREATE VIEW v_all AS SELECT id, name FROM users`)
+
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("prod LoadSchema: %v", err)
+	}
+	devSchema, err := schema.LoadSchema(ctx, devDB, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("dev LoadSchema: %v", err)
+	}
+
+	result := schema.DiffSchemas(prodSchema, devSchema)
+
+	if len(result.AddedViews) != 1 || result.AddedViews[0].Name != "v_all" {
+		t.Errorf("expected AddedViews=[v_all], got %v", result.AddedViews)
+	}
+	if len(result.ModifiedViews) != 1 || result.ModifiedViews[0].Name != "v_active" {
+		t.Errorf("expected ModifiedViews=[v_active], got %v", result.ModifiedViews)
+	}
+	if !result.HasDrift() {
+		t.Error("HasDrift() should be true")
+	}
+
+	// Migration should include both a CREATE VIEW IF NOT EXISTS and a modified view block
+	migration, err := schema.GenerateMigration(result, "sqlite", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration: %v", err)
+	}
+	if !strings.Contains(migration, "v_all") {
+		t.Error("migration should reference added view v_all")
+	}
+	if !strings.Contains(migration, "v_active") {
+		t.Error("migration should reference modified view v_active")
+	}
+}

--- a/tests/schema/views_test.go
+++ b/tests/schema/views_test.go
@@ -57,7 +57,7 @@ func TestDiffViews_RemovedView(t *testing.T) {
 	dev := &schema.Schema{Tables: map[string]schema.Table{}, Views: map[string]schema.View{}}
 	result := schema.DiffSchemas(prod, dev)
 
-	if len(result.RemovedViews) != 1 || result.RemovedViews[0] != "v_legacy" {
+	if len(result.RemovedViews) != 1 || result.RemovedViews[0].Name != "v_legacy" {
 		t.Errorf("expected RemovedViews=[v_legacy], got %v", result.RemovedViews)
 	}
 	if !result.HasDrift() {
@@ -238,7 +238,7 @@ func TestGenerateMigration_AddView_PostgreSQL_Materialized(t *testing.T) {
 }
 
 func TestGenerateMigration_DropView_CommentedByDefault(t *testing.T) {
-	diff := schema.DiffResult{RemovedViews: []string{"v_old"}}
+	diff := schema.DiffResult{RemovedViews: []schema.View{{Name: "v_old"}}}
 	sql, err := schema.GenerateMigration(diff, "sqlite", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -252,7 +252,7 @@ func TestGenerateMigration_DropView_CommentedByDefault(t *testing.T) {
 }
 
 func TestGenerateMigration_DropView_UncommentedWhenAllowed(t *testing.T) {
-	diff := schema.DiffResult{RemovedViews: []string{"v_old"}}
+	diff := schema.DiffResult{RemovedViews: []schema.View{{Name: "v_old"}}}
 	opts := &schema.MigrationOptions{AllowDropView: true}
 	sql, err := schema.GenerateMigration(diff, "sqlite", opts)
 	if err != nil {


### PR DESCRIPTION
Closes #100

## Summary

- **Introspection** (`internal/schema/introspect.go`): Added `LoadSchemaOptions` struct (variadic, backwards-compatible), `loadViews` dispatcher, and driver implementations for MySQL (`information_schema.views`), PostgreSQL (`pg_views` + `pg_matviews` for materialized), and SQLite (`sqlite_master`). MSSQL/Oracle are no-ops (Phase 2 scope). Ignore filtering is case-insensitive, matching the tables pattern.
- **Diff** (`internal/schema/diff.go`): Added `diffViews` function (sorted, deterministic) that detects added/removed/modified views; definitions normalized (lowercase + collapsed whitespace) before comparison to avoid false positives. Wired into `DiffSchemas`.
- **Migration** (`internal/schema/migrate.go`): Enhanced modified-view generation — PostgreSQL emits `CREATE OR REPLACE VIEW`; MySQL/SQLite emit DROP + CREATE (respecting `AllowDropView`). SQLite added-view creation uses `CREATE VIEW IF NOT EXISTS`.
- **Call sites** (`cmd/deepdiffdb/main.go`): All 12 `LoadSchema` callers updated to pass `schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views}`.

## Test plan

- [x] `go build ./...` clean
- [x] 22 new tests in `tests/schema/views_test.go` — all pass
  - `diffViews`: added, removed, identical, whitespace normalization, definition diff, materialized diff, deterministic sort
  - Migration: `CREATE VIEW IF NOT EXISTS` (SQLite), `CREATE MATERIALIZED VIEW` (PostgreSQL), DROP commented by default / uncommented with `AllowDropView=true`, `CREATE OR REPLACE VIEW` (PostgreSQL modified), DROP+CREATE (MySQL modified)
  - SQLite introspection: loads views, ignore list, case-insensitive ignore, empty DB, definition stored
  - End-to-end pipeline: introspect → diff → generate migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added view introspection across supported databases (MySQL, PostgreSQL, SQLite).
  * Added ability to ignore specific views from schema analysis with case-insensitive matching.
  * Added view diffing to detect added, removed, and modified views.
  * Added driver-specific SQL generation for view creation, modification, and removal operations.

* **Tests**
  * Added comprehensive test coverage for view functionality including introspection, diffing, and migration SQL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->