### PR TITLE
feat(schema): implement routines and triggers introspection, diff, and migration (Issue #101)

### DIFF
--- a/cmd/deepdiffdb/main.go
+++ b/cmd/deepdiffdb/main.go
@@ -391,11 +391,11 @@ func runFullDiff(args []string) error {
 
 	// Schema diff first
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -615,11 +615,11 @@ func runGenPack(args []string) error {
 
 	// Schema diff first
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1030,11 +1030,11 @@ func runResolveConflicts(args []string) error {
 	defer devDB.Close()
 
 	// Load schemas for row fetching
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1279,11 +1279,11 @@ func runSchemaDiff(args []string) error {
 	defer devDB.Close()
 
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1382,11 +1382,11 @@ func runSchemaMigrate(args []string) error {
 
 	// Load schemas
 	log.Info("loading database schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}
@@ -1683,11 +1683,11 @@ func runVersionCommit(args []string) error {
 	defer devDB.Close()
 
 	log.Info("loading schemas")
-	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, cfg.Prod.Driver, cfg.Prod.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load prod schema: %w", err)
 	}
-	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views})
+	devSchema, err := schema.LoadSchema(ctx, devDB, cfg.Dev.Driver, cfg.Dev.Database, cfg.Ignore.Tables, schema.LoadSchemaOptions{IgnoreViews: cfg.Ignore.Views, IgnoreRoutines: cfg.Ignore.Routines, IgnoreTriggers: cfg.Ignore.Triggers})
 	if err != nil {
 		return fmt.Errorf("load dev schema: %w", err)
 	}

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -257,6 +257,12 @@ func DiffSchemas(prod, dev *Schema) DiffResult {
 	// Diff views
 	result.AddedViews, result.RemovedViews, result.ModifiedViews = diffViews(prod.Views, dev.Views)
 
+	// Diff routines
+	result.AddedRoutines, result.RemovedRoutines, result.ModifiedRoutines = diffRoutines(prod.Routines, dev.Routines)
+
+	// Diff triggers
+	result.AddedTriggers, result.RemovedTriggers, result.ModifiedTriggers = diffTriggers(prod.Triggers, dev.Triggers)
+
 	return result
 }
 
@@ -686,4 +692,170 @@ func diffViews(prodViews, devViews map[string]View) (added []View, removed []Vie
 // Trims whitespace, collapses runs of whitespace to a single space, and lowercases.
 func normalizeViewDefinition(def string) string {
 	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(def)), " "))
+}
+
+// diffRoutines compares stored procedures and functions between prod and dev.
+func diffRoutines(prodRoutines, devRoutines map[string]Routine) (added []Routine, removed []string, modified []RoutineDiff) {
+	if prodRoutines == nil {
+		prodRoutines = make(map[string]Routine)
+	}
+	if devRoutines == nil {
+		devRoutines = make(map[string]Routine)
+	}
+
+	seen := make(map[string]struct{})
+	for name := range prodRoutines {
+		seen[name] = struct{}{}
+	}
+	for name := range devRoutines {
+		seen[name] = struct{}{}
+	}
+
+	var names []string
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		pr, prodOK := prodRoutines[name]
+		dr, devOK := devRoutines[name]
+
+		if prodOK && !devOK {
+			removed = append(removed, name)
+			continue
+		}
+		if !prodOK && devOK {
+			added = append(added, dr)
+			continue
+		}
+
+		rd := RoutineDiff{Name: name}
+		hasDiff := false
+
+		if normalizeRoutineDefinition(pr.Definition) != normalizeRoutineDefinition(dr.Definition) {
+			rd.DefinitionDiffers = true
+			rd.ProdDefinition = pr.Definition
+			rd.DevDefinition = dr.Definition
+			hasDiff = true
+		}
+		if !strings.EqualFold(pr.Kind, dr.Kind) {
+			rd.KindDiffers = true
+			rd.ProdKind = pr.Kind
+			rd.DevKind = dr.Kind
+			hasDiff = true
+		}
+		if !strings.EqualFold(pr.ReturnType, dr.ReturnType) {
+			rd.ReturnTypeDiffers = true
+			rd.ProdReturnType = pr.ReturnType
+			rd.DevReturnType = dr.ReturnType
+			hasDiff = true
+		}
+		if !strings.EqualFold(pr.Language, dr.Language) {
+			rd.LanguageDiffers = true
+			rd.ProdLanguage = pr.Language
+			rd.DevLanguage = dr.Language
+			hasDiff = true
+		}
+		if !routineParametersEqual(pr.Parameters, dr.Parameters) {
+			rd.ParametersDiffers = true
+			rd.ProdParameters = pr.Parameters
+			rd.DevParameters = dr.Parameters
+			hasDiff = true
+		}
+		if hasDiff {
+			modified = append(modified, rd)
+		}
+	}
+	return
+}
+
+// routineParametersEqual reports whether two parameter lists are identical.
+func routineParametersEqual(a, b []RoutineParameter) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !strings.EqualFold(a[i].Name, b[i].Name) ||
+			!strings.EqualFold(normalizeType(a[i].DataType), normalizeType(b[i].DataType)) ||
+			!strings.EqualFold(a[i].Mode, b[i].Mode) {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeRoutineDefinition normalizes a routine definition for comparison.
+func normalizeRoutineDefinition(def string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(def)), " "))
+}
+
+// diffTriggers compares triggers between prod and dev.
+func diffTriggers(prodTriggers, devTriggers map[string]Trigger) (added []Trigger, removed []string, modified []TriggerDiff) {
+	if prodTriggers == nil {
+		prodTriggers = make(map[string]Trigger)
+	}
+	if devTriggers == nil {
+		devTriggers = make(map[string]Trigger)
+	}
+
+	seen := make(map[string]struct{})
+	for name := range prodTriggers {
+		seen[name] = struct{}{}
+	}
+	for name := range devTriggers {
+		seen[name] = struct{}{}
+	}
+
+	var names []string
+	for n := range seen {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		pt, prodOK := prodTriggers[name]
+		dt, devOK := devTriggers[name]
+
+		if prodOK && !devOK {
+			removed = append(removed, name)
+			continue
+		}
+		if !prodOK && devOK {
+			added = append(added, dt)
+			continue
+		}
+
+		td := TriggerDiff{Name: name}
+		hasDiff := false
+
+		if normalizeRoutineDefinition(pt.Definition) != normalizeRoutineDefinition(dt.Definition) {
+			td.DefinitionDiffers = true
+			td.ProdDefinition = pt.Definition
+			td.DevDefinition = dt.Definition
+			hasDiff = true
+		}
+		if !strings.EqualFold(pt.Timing, dt.Timing) {
+			td.TimingDiffers = true
+			td.ProdTiming = pt.Timing
+			td.DevTiming = dt.Timing
+			hasDiff = true
+		}
+		if !strings.EqualFold(pt.Event, dt.Event) {
+			td.EventDiffers = true
+			td.ProdEvent = pt.Event
+			td.DevEvent = dt.Event
+			hasDiff = true
+		}
+		if pt.ForEachRow != dt.ForEachRow {
+			td.ForEachRowDiffers = true
+			td.ProdForEachRow = &pt.ForEachRow
+			td.DevForEachRow = &dt.ForEachRow
+			hasDiff = true
+		}
+		if hasDiff {
+			modified = append(modified, td)
+		}
+	}
+	return
 }

--- a/internal/schema/introspect.go
+++ b/internal/schema/introspect.go
@@ -1664,6 +1664,10 @@ func loadPostgreSQLTriggers(ctx context.Context, db *sql.DB, s *Schema, ignore m
 		       pg_get_triggerdef(t.oid) AS definition,
 		       CASE WHEN t.tgtype & 2 > 0 THEN 'BEFORE' ELSE 'AFTER' END AS timing,
 		       CASE
+		           WHEN (t.tgtype & 4 > 0) AND (t.tgtype & 8 > 0) AND (t.tgtype & 16 > 0) THEN 'INSERT OR DELETE OR UPDATE'
+		           WHEN (t.tgtype & 4 > 0) AND (t.tgtype & 8 > 0) THEN 'INSERT OR DELETE'
+		           WHEN (t.tgtype & 4 > 0) AND (t.tgtype & 16 > 0) THEN 'INSERT OR UPDATE'
+		           WHEN (t.tgtype & 8 > 0) AND (t.tgtype & 16 > 0) THEN 'DELETE OR UPDATE'
 		           WHEN t.tgtype & 4 > 0 THEN 'INSERT'
 		           WHEN t.tgtype & 8 > 0 THEN 'DELETE'
 		           WHEN t.tgtype & 16 > 0 THEN 'UPDATE'

--- a/internal/schema/introspect.go
+++ b/internal/schema/introspect.go
@@ -13,7 +13,9 @@ import (
 
 // LoadSchemaOptions provides optional configuration for LoadSchema.
 type LoadSchemaOptions struct {
-	IgnoreViews []string // View names to exclude (case-insensitive)
+	IgnoreViews    []string // View names to exclude (case-insensitive)
+	IgnoreRoutines []string // Routine names to exclude (case-insensitive)
+	IgnoreTriggers []string // Trigger names to exclude (case-insensitive)
 }
 
 // LoadSchema loads table and column metadata for the specified SQL driver into a Schema,
@@ -241,6 +243,26 @@ func LoadSchema(ctx context.Context, db *sql.DB, driver string, database string,
 	log.Debug("loading views")
 	if err := loadViews(ctx, db, driver, database, s, ignoreViews); err != nil {
 		return nil, fmt.Errorf("load views: %w", err)
+	}
+
+	// Load routines
+	var ignoreRoutines []string
+	if len(opts) > 0 {
+		ignoreRoutines = opts[0].IgnoreRoutines
+	}
+	log.Debug("loading routines")
+	if err := loadRoutines(ctx, db, driver, database, s, ignoreRoutines); err != nil {
+		return nil, fmt.Errorf("load routines: %w", err)
+	}
+
+	// Load triggers
+	var ignoreTriggers []string
+	if len(opts) > 0 {
+		ignoreTriggers = opts[0].IgnoreTriggers
+	}
+	log.Debug("loading triggers")
+	if err := loadTriggers(ctx, db, driver, database, s, ignoreTriggers); err != nil {
+		return nil, fmt.Errorf("load triggers: %w", err)
 	}
 
 	// Calculate total columns
@@ -1439,4 +1461,315 @@ func loadOracleForeignKeys(ctx context.Context, db *sql.DB, s *Schema) error {
 		s.Tables[tableName] = t
 	}
 	return nil
+}
+
+// loadRoutines queries the database for stored procedure and function metadata and
+// populates the Routines map in the schema. It dispatches to driver-specific functions.
+func loadRoutines(ctx context.Context, db *sql.DB, driver string, database string, s *Schema, ignoreRoutines []string) error {
+	ignore := make(map[string]struct{}, len(ignoreRoutines))
+	for _, r := range ignoreRoutines {
+		ignore[strings.ToLower(r)] = struct{}{}
+	}
+	switch driver {
+	case "mysql":
+		return loadMySQLRoutines(ctx, db, database, s, ignore)
+	case "postgres", "postgresql":
+		return loadPostgreSQLRoutines(ctx, db, s, ignore)
+	case "sqlite", "mssql", "oracle":
+		return nil // SQLite has no routines; MSSQL/Oracle deferred
+	default:
+		return fmt.Errorf("routine introspection unsupported for driver: %s", driver)
+	}
+}
+
+// loadMySQLRoutines queries information_schema.routines and information_schema.parameters
+// to load stored procedure and function metadata for the given database.
+func loadMySQLRoutines(ctx context.Context, db *sql.DB, database string, s *Schema, ignore map[string]struct{}) error {
+	// Load routine metadata
+	rows, err := db.QueryContext(ctx, `
+		SELECT routine_name, routine_type, routine_definition,
+		       COALESCE(data_type, '') AS return_type,
+		       COALESCE(external_language, 'SQL') AS language
+		FROM information_schema.routines
+		WHERE routine_schema = ?
+		ORDER BY routine_name
+	`, database)
+	if err != nil {
+		return fmt.Errorf("mysql routines: %w", err)
+	}
+	defer rows.Close()
+
+	if s.Routines == nil {
+		s.Routines = make(map[string]Routine)
+	}
+	for rows.Next() {
+		var name, kind, definition, returnType, language string
+		if err := rows.Scan(&name, &kind, &definition, &returnType, &language); err != nil {
+			return fmt.Errorf("mysql routines scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		s.Routines[name] = Routine{
+			Name:       name,
+			Kind:       kind,
+			Definition: definition,
+			ReturnType: returnType,
+			Language:   language,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// Load parameters for each routine
+	paramRows, err := db.QueryContext(ctx, `
+		SELECT specific_name, parameter_name, data_type,
+		       COALESCE(parameter_mode, 'IN') AS parameter_mode
+		FROM information_schema.parameters
+		WHERE specific_schema = ? AND parameter_name IS NOT NULL
+		ORDER BY specific_name, ordinal_position
+	`, database)
+	if err != nil {
+		return fmt.Errorf("mysql routine parameters: %w", err)
+	}
+	defer paramRows.Close()
+
+	for paramRows.Next() {
+		var routineName, paramName, dataType, mode string
+		if err := paramRows.Scan(&routineName, &paramName, &dataType, &mode); err != nil {
+			return fmt.Errorf("mysql routine parameters scan: %w", err)
+		}
+		r, ok := s.Routines[routineName]
+		if !ok {
+			continue
+		}
+		r.Parameters = append(r.Parameters, RoutineParameter{
+			Name:     paramName,
+			DataType: dataType,
+			Mode:     mode,
+		})
+		s.Routines[routineName] = r
+	}
+	return paramRows.Err()
+}
+
+// loadPostgreSQLRoutines queries pg_proc to load function and procedure metadata.
+func loadPostgreSQLRoutines(ctx context.Context, db *sql.DB, s *Schema, ignore map[string]struct{}) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT p.proname,
+		       CASE p.prokind WHEN 'f' THEN 'FUNCTION' WHEN 'p' THEN 'PROCEDURE' ELSE 'FUNCTION' END AS kind,
+		       pg_get_functiondef(p.oid) AS definition,
+		       COALESCE(t.typname, '') AS return_type,
+		       COALESCE(l.lanname, 'sql') AS language
+		FROM pg_proc p
+		JOIN pg_namespace n ON n.oid = p.pronamespace
+		LEFT JOIN pg_type t ON t.oid = p.prorettype
+		LEFT JOIN pg_language l ON l.oid = p.prolang
+		WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+		  AND p.prokind IN ('f', 'p')
+		ORDER BY p.proname
+	`)
+	if err != nil {
+		return fmt.Errorf("postgresql routines: %w", err)
+	}
+	defer rows.Close()
+
+	if s.Routines == nil {
+		s.Routines = make(map[string]Routine)
+	}
+	for rows.Next() {
+		var name, kind, definition, returnType, language string
+		if err := rows.Scan(&name, &kind, &definition, &returnType, &language); err != nil {
+			return fmt.Errorf("postgresql routines scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		s.Routines[name] = Routine{
+			Name:       name,
+			Kind:       kind,
+			Definition: strings.TrimSpace(definition),
+			ReturnType: returnType,
+			Language:   language,
+		}
+	}
+	return rows.Err()
+}
+
+// loadTriggers queries the database for trigger metadata and populates the Triggers map
+// in the schema. It dispatches to driver-specific trigger loading functions.
+func loadTriggers(ctx context.Context, db *sql.DB, driver string, database string, s *Schema, ignoreTriggers []string) error {
+	ignore := make(map[string]struct{}, len(ignoreTriggers))
+	for _, t := range ignoreTriggers {
+		ignore[strings.ToLower(t)] = struct{}{}
+	}
+	switch driver {
+	case "mysql":
+		return loadMySQLTriggers(ctx, db, database, s, ignore)
+	case "postgres", "postgresql":
+		return loadPostgreSQLTriggers(ctx, db, s, ignore)
+	case "sqlite":
+		return loadSQLiteTriggers(ctx, db, s, ignore)
+	case "mssql", "oracle":
+		return nil // deferred
+	default:
+		return fmt.Errorf("trigger introspection unsupported for driver: %s", driver)
+	}
+}
+
+// loadMySQLTriggers queries information_schema.triggers to load trigger metadata.
+func loadMySQLTriggers(ctx context.Context, db *sql.DB, database string, s *Schema, ignore map[string]struct{}) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT trigger_name, event_object_table, action_timing,
+		       event_manipulation, action_statement,
+		       action_orientation
+		FROM information_schema.triggers
+		WHERE trigger_schema = ?
+		ORDER BY trigger_name
+	`, database)
+	if err != nil {
+		return fmt.Errorf("mysql triggers: %w", err)
+	}
+	defer rows.Close()
+
+	if s.Triggers == nil {
+		s.Triggers = make(map[string]Trigger)
+	}
+	for rows.Next() {
+		var name, table, timing, event, definition, orientation string
+		if err := rows.Scan(&name, &table, &timing, &event, &definition, &orientation); err != nil {
+			return fmt.Errorf("mysql triggers scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		s.Triggers[name] = Trigger{
+			Name:       name,
+			Table:      table,
+			Timing:     timing,
+			Event:      event,
+			Definition: definition,
+			ForEachRow: strings.EqualFold(orientation, "ROW"),
+		}
+	}
+	return rows.Err()
+}
+
+// loadPostgreSQLTriggers queries pg_trigger to load trigger metadata.
+func loadPostgreSQLTriggers(ctx context.Context, db *sql.DB, s *Schema, ignore map[string]struct{}) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT t.tgname,
+		       c.relname AS table_name,
+		       pg_get_triggerdef(t.oid) AS definition,
+		       CASE WHEN t.tgtype & 2 > 0 THEN 'BEFORE' ELSE 'AFTER' END AS timing,
+		       CASE
+		           WHEN t.tgtype & 4 > 0 THEN 'INSERT'
+		           WHEN t.tgtype & 8 > 0 THEN 'DELETE'
+		           WHEN t.tgtype & 16 > 0 THEN 'UPDATE'
+		           ELSE 'UNKNOWN'
+		       END AS event,
+		       (t.tgtype & 1) > 0 AS for_each_row
+		FROM pg_trigger t
+		JOIN pg_class c ON c.oid = t.tgrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE NOT t.tgisinternal
+		  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY t.tgname
+	`)
+	if err != nil {
+		return fmt.Errorf("postgresql triggers: %w", err)
+	}
+	defer rows.Close()
+
+	if s.Triggers == nil {
+		s.Triggers = make(map[string]Trigger)
+	}
+	for rows.Next() {
+		var name, table, definition, timing, event string
+		var forEachRow bool
+		if err := rows.Scan(&name, &table, &definition, &timing, &event, &forEachRow); err != nil {
+			return fmt.Errorf("postgresql triggers scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		s.Triggers[name] = Trigger{
+			Name:       name,
+			Table:      table,
+			Timing:     timing,
+			Event:      event,
+			Definition: strings.TrimSpace(definition),
+			ForEachRow: forEachRow,
+		}
+	}
+	return rows.Err()
+}
+
+// loadSQLiteTriggers queries sqlite_master to load trigger metadata.
+func loadSQLiteTriggers(ctx context.Context, db *sql.DB, s *Schema, ignore map[string]struct{}) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT name, tbl_name, sql
+		FROM sqlite_master
+		WHERE type = 'trigger'
+		ORDER BY name
+	`)
+	if err != nil {
+		return fmt.Errorf("sqlite triggers: %w", err)
+	}
+	defer rows.Close()
+
+	if s.Triggers == nil {
+		s.Triggers = make(map[string]Trigger)
+	}
+	for rows.Next() {
+		var name, tableName string
+		var sqlDef sql.NullString
+		if err := rows.Scan(&name, &tableName, &sqlDef); err != nil {
+			return fmt.Errorf("sqlite triggers scan: %w", err)
+		}
+		if _, skip := ignore[strings.ToLower(name)]; skip {
+			continue
+		}
+		definition := ""
+		if sqlDef.Valid {
+			definition = sqlDef.String
+		}
+		// Parse timing and event from the definition
+		timing, event, forEachRow := parseSQLiteTriggerMeta(definition)
+		s.Triggers[name] = Trigger{
+			Name:       name,
+			Table:      tableName,
+			Timing:     timing,
+			Event:      event,
+			Definition: definition,
+			ForEachRow: forEachRow,
+		}
+	}
+	return rows.Err()
+}
+
+// parseSQLiteTriggerMeta extracts timing, event, and ForEachRow from a SQLite
+// CREATE TRIGGER statement. SQLite syntax:
+//
+//	CREATE TRIGGER <name> BEFORE|AFTER|INSTEAD OF INSERT|UPDATE|DELETE ON <table>
+//	[FOR EACH ROW] BEGIN ... END
+func parseSQLiteTriggerMeta(sql string) (timing, event string, forEachRow bool) {
+	upper := strings.ToUpper(sql)
+	// Timing
+	for _, t := range []string{"INSTEAD OF", "BEFORE", "AFTER"} {
+		if strings.Contains(upper, t) {
+			timing = t
+			break
+		}
+	}
+	// Event
+	for _, e := range []string{"INSERT", "UPDATE", "DELETE"} {
+		if strings.Contains(upper, e) {
+			event = e
+			break
+		}
+	}
+	forEachRow = strings.Contains(upper, "FOR EACH ROW")
+	return
 }

--- a/tests/schema/routines_triggers_test.go
+++ b/tests/schema/routines_triggers_test.go
@@ -1,0 +1,754 @@
+package schema_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/iamvirul/deepdiff-db/internal/schema"
+)
+
+// ── diffRoutines ──────────────────────────────────────────────────────────────
+
+func TestDiffRoutines_AddedRoutine(t *testing.T) {
+	prod := &schema.Schema{Tables: map[string]schema.Table{}}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_new": {Name: "fn_new", Kind: "FUNCTION", Definition: "BEGIN RETURN 1; END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedRoutines) != 1 {
+		t.Fatalf("expected 1 added routine, got %d", len(result.AddedRoutines))
+	}
+	if result.AddedRoutines[0].Name != "fn_new" {
+		t.Errorf("expected fn_new, got %s", result.AddedRoutines[0].Name)
+	}
+	if len(result.RemovedRoutines) != 0 || len(result.ModifiedRoutines) != 0 {
+		t.Error("expected no removed or modified routines")
+	}
+}
+
+func TestDiffRoutines_RemovedRoutine(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_old": {Name: "fn_old", Kind: "PROCEDURE", Definition: "BEGIN END"},
+		},
+	}
+	dev := &schema.Schema{Tables: map[string]schema.Table{}}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.RemovedRoutines) != 1 {
+		t.Fatalf("expected 1 removed routine, got %d", len(result.RemovedRoutines))
+	}
+	if result.RemovedRoutines[0] != "fn_old" {
+		t.Errorf("expected fn_old, got %s", result.RemovedRoutines[0])
+	}
+}
+
+func TestDiffRoutines_IdenticalRoutine_NoDiff(t *testing.T) {
+	r := schema.Routine{Name: "fn_same", Kind: "FUNCTION", Definition: "BEGIN RETURN 42; END", ReturnType: "INT", Language: "sql"}
+	prod := &schema.Schema{Tables: map[string]schema.Table{}, Routines: map[string]schema.Routine{"fn_same": r}}
+	dev := &schema.Schema{Tables: map[string]schema.Table{}, Routines: map[string]schema.Routine{"fn_same": r}}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedRoutines) != 0 || len(result.RemovedRoutines) != 0 || len(result.ModifiedRoutines) != 0 {
+		t.Error("expected no diff for identical routines")
+	}
+}
+
+func TestDiffRoutines_DefinitionDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_calc": {Name: "fn_calc", Kind: "FUNCTION", Definition: "BEGIN RETURN 1; END"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_calc": {Name: "fn_calc", Kind: "FUNCTION", Definition: "BEGIN RETURN 2; END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedRoutines) != 1 {
+		t.Fatalf("expected 1 modified routine, got %d", len(result.ModifiedRoutines))
+	}
+	rd := result.ModifiedRoutines[0]
+	if !rd.DefinitionDiffers {
+		t.Error("DefinitionDiffers should be true")
+	}
+	if rd.ProdDefinition != "BEGIN RETURN 1; END" || rd.DevDefinition != "BEGIN RETURN 2; END" {
+		t.Errorf("unexpected definitions: prod=%q dev=%q", rd.ProdDefinition, rd.DevDefinition)
+	}
+}
+
+func TestDiffRoutines_KindDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_x": {Name: "fn_x", Kind: "FUNCTION", Definition: "BEGIN END"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_x": {Name: "fn_x", Kind: "PROCEDURE", Definition: "BEGIN END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedRoutines) != 1 {
+		t.Fatalf("expected 1 modified routine, got %d", len(result.ModifiedRoutines))
+	}
+	rd := result.ModifiedRoutines[0]
+	if !rd.KindDiffers {
+		t.Error("KindDiffers should be true")
+	}
+	if rd.ProdKind != "FUNCTION" || rd.DevKind != "PROCEDURE" {
+		t.Errorf("unexpected kinds: prod=%q dev=%q", rd.ProdKind, rd.DevKind)
+	}
+}
+
+func TestDiffRoutines_ReturnTypeDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_price": {Name: "fn_price", Kind: "FUNCTION", Definition: "BEGIN RETURN 0; END", ReturnType: "INT"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_price": {Name: "fn_price", Kind: "FUNCTION", Definition: "BEGIN RETURN 0; END", ReturnType: "DECIMAL(10,2)"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedRoutines) != 1 {
+		t.Fatalf("expected 1 modified routine, got %d", len(result.ModifiedRoutines))
+	}
+	rd := result.ModifiedRoutines[0]
+	if !rd.ReturnTypeDiffers {
+		t.Error("ReturnTypeDiffers should be true")
+	}
+}
+
+func TestDiffRoutines_ParametersDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_add": {
+				Name:       "fn_add",
+				Kind:       "FUNCTION",
+				Definition: "BEGIN RETURN a + b; END",
+				Parameters: []schema.RoutineParameter{
+					{Name: "a", DataType: "INT", Mode: "IN"},
+					{Name: "b", DataType: "INT", Mode: "IN"},
+				},
+			},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_add": {
+				Name:       "fn_add",
+				Kind:       "FUNCTION",
+				Definition: "BEGIN RETURN a + b; END",
+				Parameters: []schema.RoutineParameter{
+					{Name: "a", DataType: "INT", Mode: "IN"},
+					{Name: "b", DataType: "BIGINT", Mode: "IN"},
+				},
+			},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedRoutines) != 1 {
+		t.Fatalf("expected 1 modified routine, got %d", len(result.ModifiedRoutines))
+	}
+	if !result.ModifiedRoutines[0].ParametersDiffers {
+		t.Error("ParametersDiffers should be true")
+	}
+}
+
+func TestDiffRoutines_NormalizedDefinition_WhitespaceDifference(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_ws": {Name: "fn_ws", Kind: "FUNCTION", Definition: "BEGIN  RETURN  1;  END"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_ws": {Name: "fn_ws", Kind: "FUNCTION", Definition: "BEGIN RETURN 1; END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedRoutines) != 0 {
+		t.Error("whitespace-only definition differences should not produce a diff")
+	}
+}
+
+func TestDiffRoutines_SortOrder(t *testing.T) {
+	prod := &schema.Schema{Tables: map[string]schema.Table{}}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_z": {Name: "fn_z", Kind: "FUNCTION", Definition: "BEGIN END"},
+			"fn_a": {Name: "fn_a", Kind: "FUNCTION", Definition: "BEGIN END"},
+			"fn_m": {Name: "fn_m", Kind: "FUNCTION", Definition: "BEGIN END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedRoutines) != 3 {
+		t.Fatalf("expected 3 added routines, got %d", len(result.AddedRoutines))
+	}
+	if result.AddedRoutines[0].Name != "fn_a" || result.AddedRoutines[1].Name != "fn_m" || result.AddedRoutines[2].Name != "fn_z" {
+		t.Errorf("added routines not sorted: got %s, %s, %s",
+			result.AddedRoutines[0].Name, result.AddedRoutines[1].Name, result.AddedRoutines[2].Name)
+	}
+}
+
+// ── diffTriggers ──────────────────────────────────────────────────────────────
+
+func TestDiffTriggers_AddedTrigger(t *testing.T) {
+	prod := &schema.Schema{Tables: map[string]schema.Table{}}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_audit": {Name: "trg_audit", Table: "orders", Timing: "AFTER", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_audit AFTER INSERT ON orders FOR EACH ROW BEGIN END", ForEachRow: true},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedTriggers) != 1 {
+		t.Fatalf("expected 1 added trigger, got %d", len(result.AddedTriggers))
+	}
+	if result.AddedTriggers[0].Name != "trg_audit" {
+		t.Errorf("expected trg_audit, got %s", result.AddedTriggers[0].Name)
+	}
+}
+
+func TestDiffTriggers_RemovedTrigger(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_old": {Name: "trg_old", Table: "users", Timing: "BEFORE", Event: "DELETE",
+				Definition: "CREATE TRIGGER trg_old BEFORE DELETE ON users BEGIN END"},
+		},
+	}
+	dev := &schema.Schema{Tables: map[string]schema.Table{}}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.RemovedTriggers) != 1 {
+		t.Fatalf("expected 1 removed trigger, got %d", len(result.RemovedTriggers))
+	}
+	if result.RemovedTriggers[0] != "trg_old" {
+		t.Errorf("expected trg_old, got %s", result.RemovedTriggers[0])
+	}
+}
+
+func TestDiffTriggers_IdenticalTrigger_NoDiff(t *testing.T) {
+	trg := schema.Trigger{
+		Name: "trg_same", Table: "orders", Timing: "AFTER", Event: "INSERT",
+		Definition: "CREATE TRIGGER trg_same AFTER INSERT ON orders FOR EACH ROW BEGIN END",
+		ForEachRow: true,
+	}
+	prod := &schema.Schema{Tables: map[string]schema.Table{}, Triggers: map[string]schema.Trigger{"trg_same": trg}}
+	dev := &schema.Schema{Tables: map[string]schema.Table{}, Triggers: map[string]schema.Trigger{"trg_same": trg}}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedTriggers) != 0 || len(result.RemovedTriggers) != 0 || len(result.ModifiedTriggers) != 0 {
+		t.Error("expected no diff for identical triggers")
+	}
+}
+
+func TestDiffTriggers_TimingDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_t": {Name: "trg_t", Table: "orders", Timing: "BEFORE", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_t BEFORE INSERT ON orders BEGIN END"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_t": {Name: "trg_t", Table: "orders", Timing: "AFTER", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_t AFTER INSERT ON orders BEGIN END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedTriggers) != 1 {
+		t.Fatalf("expected 1 modified trigger, got %d", len(result.ModifiedTriggers))
+	}
+	td := result.ModifiedTriggers[0]
+	if !td.TimingDiffers {
+		t.Error("TimingDiffers should be true")
+	}
+	if td.ProdTiming != "BEFORE" || td.DevTiming != "AFTER" {
+		t.Errorf("unexpected timing: prod=%q dev=%q", td.ProdTiming, td.DevTiming)
+	}
+}
+
+func TestDiffTriggers_EventDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_e": {Name: "trg_e", Table: "orders", Timing: "AFTER", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_e AFTER INSERT ON orders BEGIN END"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_e": {Name: "trg_e", Table: "orders", Timing: "AFTER", Event: "UPDATE",
+				Definition: "CREATE TRIGGER trg_e AFTER UPDATE ON orders BEGIN END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedTriggers) != 1 {
+		t.Fatalf("expected 1 modified trigger, got %d", len(result.ModifiedTriggers))
+	}
+	td := result.ModifiedTriggers[0]
+	if !td.EventDiffers {
+		t.Error("EventDiffers should be true")
+	}
+	if td.ProdEvent != "INSERT" || td.DevEvent != "UPDATE" {
+		t.Errorf("unexpected events: prod=%q dev=%q", td.ProdEvent, td.DevEvent)
+	}
+}
+
+func TestDiffTriggers_DefinitionDiffers(t *testing.T) {
+	prod := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_d": {Name: "trg_d", Table: "orders", Timing: "AFTER", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_d AFTER INSERT ON orders BEGIN SELECT 1; END"},
+		},
+	}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_d": {Name: "trg_d", Table: "orders", Timing: "AFTER", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_d AFTER INSERT ON orders BEGIN SELECT 2; END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedTriggers) != 1 {
+		t.Fatalf("expected 1 modified trigger, got %d", len(result.ModifiedTriggers))
+	}
+	if !result.ModifiedTriggers[0].DefinitionDiffers {
+		t.Error("DefinitionDiffers should be true")
+	}
+}
+
+func TestDiffTriggers_SortOrder(t *testing.T) {
+	prod := &schema.Schema{Tables: map[string]schema.Table{}}
+	dev := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_z": {Name: "trg_z", Table: "t", Timing: "AFTER", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_z AFTER INSERT ON t BEGIN END"},
+			"trg_a": {Name: "trg_a", Table: "t", Timing: "AFTER", Event: "INSERT",
+				Definition: "CREATE TRIGGER trg_a AFTER INSERT ON t BEGIN END"},
+		},
+	}
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedTriggers) != 2 {
+		t.Fatalf("expected 2 added triggers, got %d", len(result.AddedTriggers))
+	}
+	if result.AddedTriggers[0].Name != "trg_a" || result.AddedTriggers[1].Name != "trg_z" {
+		t.Errorf("added triggers not sorted: got %s, %s", result.AddedTriggers[0].Name, result.AddedTriggers[1].Name)
+	}
+}
+
+// ── SQLite trigger introspection ──────────────────────────────────────────────
+
+func newSQLiteDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestSQLiteTriggers_LoadsTriggers(t *testing.T) {
+	db := newSQLiteDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `CREATE TABLE orders (id INTEGER PRIMARY KEY, total REAL)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		CREATE TRIGGER trg_audit AFTER INSERT ON orders
+		FOR EACH ROW BEGIN SELECT 1; END
+	`)
+	if err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	trg, ok := s.Triggers["trg_audit"]
+	if !ok {
+		t.Fatal("trg_audit not found in schema")
+	}
+	if trg.Table != "orders" {
+		t.Errorf("Table: want %q, got %q", "orders", trg.Table)
+	}
+	if trg.Timing != "AFTER" {
+		t.Errorf("Timing: want AFTER, got %q", trg.Timing)
+	}
+	if trg.Event != "INSERT" {
+		t.Errorf("Event: want INSERT, got %q", trg.Event)
+	}
+	if !trg.ForEachRow {
+		t.Error("ForEachRow should be true")
+	}
+	if trg.Definition == "" {
+		t.Error("Definition should not be empty")
+	}
+}
+
+func TestSQLiteTriggers_BeforeDelete(t *testing.T) {
+	db := newSQLiteDB(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TRIGGER trg_before_del BEFORE DELETE ON users BEGIN SELECT 1; END`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	trg, ok := s.Triggers["trg_before_del"]
+	if !ok {
+		t.Fatal("trg_before_del not found")
+	}
+	if trg.Timing != "BEFORE" {
+		t.Errorf("Timing: want BEFORE, got %q", trg.Timing)
+	}
+	if trg.Event != "DELETE" {
+		t.Errorf("Event: want DELETE, got %q", trg.Event)
+	}
+	if trg.ForEachRow {
+		t.Error("ForEachRow should be false (no FOR EACH ROW clause)")
+	}
+}
+
+func TestSQLiteTriggers_IgnoreTrigger(t *testing.T) {
+	db := newSQLiteDB(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TRIGGER trg_keep AFTER INSERT ON t BEGIN SELECT 1; END`); err != nil {
+		t.Fatalf("create trg_keep: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TRIGGER trg_skip AFTER INSERT ON t BEGIN SELECT 2; END`); err != nil {
+		t.Fatalf("create trg_skip: %v", err)
+	}
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil,
+		schema.LoadSchemaOptions{IgnoreTriggers: []string{"trg_skip"}})
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	if _, found := s.Triggers["trg_skip"]; found {
+		t.Error("trg_skip should have been ignored")
+	}
+	if _, found := s.Triggers["trg_keep"]; !found {
+		t.Error("trg_keep should be present")
+	}
+}
+
+func TestSQLiteTriggers_CaseInsensitiveIgnore(t *testing.T) {
+	db := newSQLiteDB(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TRIGGER TRG_UPPER AFTER INSERT ON t BEGIN SELECT 1; END`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil,
+		schema.LoadSchemaOptions{IgnoreTriggers: []string{"trg_upper"}})
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+
+	if _, found := s.Triggers["TRG_UPPER"]; found {
+		t.Error("TRG_UPPER should have been ignored (case-insensitive match)")
+	}
+}
+
+func TestSQLiteTriggers_NoTriggers_EmptyMap(t *testing.T) {
+	db := newSQLiteDB(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	s, err := schema.LoadSchema(ctx, db, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema: %v", err)
+	}
+	if len(s.Triggers) != 0 {
+		t.Errorf("expected empty triggers map, got %d entries", len(s.Triggers))
+	}
+}
+
+// ── migration generation: routines ───────────────────────────────────────────
+
+func TestGenerateMigration_AddedRoutine_UsesDefinition(t *testing.T) {
+	def := "CREATE FUNCTION fn_calc() RETURNS INT BEGIN RETURN 42; END"
+	diff := schema.DiffResult{
+		AddedRoutines: []schema.Routine{
+			{Name: "fn_calc", Kind: "FUNCTION", Definition: def},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration error: %v", err)
+	}
+	if !strings.Contains(sql, def) {
+		t.Errorf("expected routine definition in output, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_RemovedRoutine_CommentedByDefault(t *testing.T) {
+	diff := schema.DiffResult{
+		RemovedRoutines: []string{"fn_old"},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration error: %v", err)
+	}
+	if !strings.Contains(sql, "-- ") {
+		t.Error("removed routine should be commented out by default")
+	}
+	if !strings.Contains(sql, "fn_old") {
+		t.Error("removed routine name should appear in output")
+	}
+}
+
+func TestGenerateMigration_RemovedRoutine_UncommentedWhenAllowed(t *testing.T) {
+	diff := schema.DiffResult{
+		RemovedRoutines: []string{"fn_old"},
+	}
+	prodSchema := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Routines: map[string]schema.Routine{
+			"fn_old": {Name: "fn_old", Kind: "FUNCTION"},
+		},
+	}
+	opts := &schema.MigrationOptions{AllowDropRoutine: true}
+	sql, err := schema.GenerateMigrationWithSchemas(diff, "mysql", opts, prodSchema)
+	if err != nil {
+		t.Fatalf("GenerateMigrationWithSchemas error: %v", err)
+	}
+	if !containsUncommented(sql, "DROP FUNCTION") {
+		t.Errorf("expected uncommented DROP FUNCTION when AllowDropRoutine=true, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_ModifiedRoutine_CommentOnly(t *testing.T) {
+	diff := schema.DiffResult{
+		ModifiedRoutines: []schema.RoutineDiff{
+			{Name: "fn_price", DefinitionDiffers: true, ProdDefinition: "BEGIN RETURN 1; END", DevDefinition: "BEGIN RETURN 2; END"},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration error: %v", err)
+	}
+	if !strings.Contains(sql, "fn_price") {
+		t.Error("modified routine name should appear in output")
+	}
+	// Modified routines only produce comments — no executable DROP/CREATE
+	if strings.Contains(sql, "DROP FUNCTION fn_price") || strings.Contains(sql, "CREATE FUNCTION fn_price") {
+		t.Error("modified routine should not produce executable DROP/CREATE statements")
+	}
+}
+
+// ── migration generation: triggers ───────────────────────────────────────────
+
+func TestGenerateMigration_AddedTrigger_UsesDefinition(t *testing.T) {
+	def := "CREATE TRIGGER trg_audit AFTER INSERT ON orders FOR EACH ROW BEGIN SELECT 1; END"
+	diff := schema.DiffResult{
+		AddedTriggers: []schema.Trigger{
+			{Name: "trg_audit", Table: "orders", Timing: "AFTER", Event: "INSERT", Definition: def, ForEachRow: true},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration error: %v", err)
+	}
+	if !strings.Contains(sql, def) {
+		t.Errorf("expected trigger definition in output, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_AddedTrigger_EmptyDefinition_Error(t *testing.T) {
+	diff := schema.DiffResult{
+		AddedTriggers: []schema.Trigger{
+			{Name: "trg_bad", Table: "orders", Timing: "AFTER", Event: "INSERT"},
+		},
+	}
+	_, err := schema.GenerateMigration(diff, "sqlite", nil)
+	if err == nil {
+		t.Error("expected error for trigger with empty Definition, got nil")
+	}
+}
+
+func TestGenerateMigration_RemovedTrigger_CommentedByDefault(t *testing.T) {
+	diff := schema.DiffResult{
+		RemovedTriggers: []string{"trg_old"},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration error: %v", err)
+	}
+	if !strings.Contains(sql, "-- ") {
+		t.Error("removed trigger should be commented out by default")
+	}
+	if !strings.Contains(sql, "trg_old") {
+		t.Error("removed trigger name should appear in output")
+	}
+}
+
+func TestGenerateMigration_RemovedTrigger_UncommentedWhenAllowed(t *testing.T) {
+	diff := schema.DiffResult{
+		RemovedTriggers: []string{"trg_old"},
+	}
+	prodSchema := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_old": {Name: "trg_old", Table: "orders"},
+		},
+	}
+	opts := &schema.MigrationOptions{AllowDropTrigger: true}
+	sql, err := schema.GenerateMigrationWithSchemas(diff, "mysql", opts, prodSchema)
+	if err != nil {
+		t.Fatalf("GenerateMigrationWithSchemas error: %v", err)
+	}
+	if !containsUncommented(sql, "DROP TRIGGER") {
+		t.Errorf("expected uncommented DROP TRIGGER when AllowDropTrigger=true, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_RemovedTrigger_PostgreSQL_NeedsProdSchema(t *testing.T) {
+	diff := schema.DiffResult{
+		RemovedTriggers: []string{"trg_pg"},
+	}
+	prodSchema := &schema.Schema{
+		Tables: map[string]schema.Table{},
+		Triggers: map[string]schema.Trigger{
+			"trg_pg": {Name: "trg_pg", Table: "orders"},
+		},
+	}
+	opts := &schema.MigrationOptions{AllowDropTrigger: true}
+	sql, err := schema.GenerateMigrationWithSchemas(diff, "postgres", opts, prodSchema)
+	if err != nil {
+		t.Fatalf("GenerateMigrationWithSchemas error: %v", err)
+	}
+	if !strings.Contains(sql, "ON") {
+		t.Errorf("PostgreSQL DROP TRIGGER should include ON <table>, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_ModifiedTrigger_CommentOnly(t *testing.T) {
+	diff := schema.DiffResult{
+		ModifiedTriggers: []schema.TriggerDiff{
+			{Name: "trg_sync", EventDiffers: true, ProdEvent: "INSERT", DevEvent: "UPDATE"},
+		},
+	}
+	sql, err := schema.GenerateMigration(diff, "mysql", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration error: %v", err)
+	}
+	if !strings.Contains(sql, "trg_sync") {
+		t.Error("modified trigger name should appear in output")
+	}
+	if containsUncommented(sql, "DROP TRIGGER") {
+		t.Error("modified trigger should not produce executable DROP TRIGGER")
+	}
+}
+
+// ── end-to-end pipeline: introspect → diff → migrate ─────────────────────────
+
+func TestEndToEnd_RoutinesAndTriggers_SQLite(t *testing.T) {
+	// prod: has trg_legacy (to be removed), no trg_new
+	prodDB := newSQLiteDB(t)
+	devDB := newSQLiteDB(t)
+	ctx := context.Background()
+
+	for _, db := range []*sql.DB{prodDB, devDB} {
+		if _, err := db.ExecContext(ctx, `CREATE TABLE orders (id INTEGER PRIMARY KEY, total REAL)`); err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+	}
+
+	// prod has trg_legacy
+	if _, err := prodDB.ExecContext(ctx, `
+		CREATE TRIGGER trg_legacy AFTER INSERT ON orders FOR EACH ROW BEGIN SELECT 1; END
+	`); err != nil {
+		t.Fatalf("prod create trigger: %v", err)
+	}
+	// dev has trg_new
+	if _, err := devDB.ExecContext(ctx, `
+		CREATE TRIGGER trg_new AFTER UPDATE ON orders FOR EACH ROW BEGIN SELECT 2; END
+	`); err != nil {
+		t.Fatalf("dev create trigger: %v", err)
+	}
+
+	prodSchema, err := schema.LoadSchema(ctx, prodDB, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema prod: %v", err)
+	}
+	devSchema, err := schema.LoadSchema(ctx, devDB, "sqlite", "", nil)
+	if err != nil {
+		t.Fatalf("LoadSchema dev: %v", err)
+	}
+
+	diff := schema.DiffSchemas(prodSchema, devSchema)
+
+	if len(diff.AddedTriggers) != 1 || diff.AddedTriggers[0].Name != "trg_new" {
+		t.Errorf("expected trg_new in AddedTriggers, got %v", diff.AddedTriggers)
+	}
+	if len(diff.RemovedTriggers) != 1 || diff.RemovedTriggers[0] != "trg_legacy" {
+		t.Errorf("expected trg_legacy in RemovedTriggers, got %v", diff.RemovedTriggers)
+	}
+
+	sql, err := schema.GenerateMigration(diff, "sqlite", nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration: %v", err)
+	}
+	if !strings.Contains(sql, "trg_new") {
+		t.Error("migration should reference trg_new")
+	}
+	if !strings.Contains(sql, "trg_legacy") {
+		t.Error("migration should reference trg_legacy")
+	}
+	if !strings.Contains(sql, "BEGIN;") || !strings.Contains(sql, "COMMIT;") {
+		t.Error("migration should be wrapped in a transaction")
+	}
+}


### PR DESCRIPTION
## Summary

- **Introspection**: `loadRoutines` (MySQL via `information_schema.routines`+`parameters`, PostgreSQL via `pg_proc`/`pg_get_functiondef`) and `loadTriggers` (MySQL via `information_schema.triggers`, PostgreSQL via `pg_trigger` with bit-mask timing/event, SQLite via `sqlite_master`+`parseSQLiteTriggerMeta`)
- **Diff**: `diffRoutines` and `diffTriggers` follow the established three-way added/removed/modified pattern; definition comparison uses whitespace-normalized, case-folded comparison; routine diff also covers kind, return type, language, and parameter list
- **Config**: `LoadSchemaOptions` extended with `IgnoreRoutines` and `IgnoreTriggers`; all `LoadSchema` call sites in `main.go` updated

## Test plan

- [x] `diffRoutines`: added, removed, identical (no diff), definition diff, kind diff, return-type diff, parameters diff, whitespace normalisation, sort order
- [x] `diffTriggers`: added, removed, identical (no diff), timing diff, event diff, definition diff, sort order
- [x] SQLite trigger introspection: loads triggers with correct timing/event/ForEachRow, BEFORE DELETE, ignore list, case-insensitive ignore, no-trigger empty-map
- [x] Migration generation (routines): added uses definition verbatim, removed commented-by-default, removed uncommented when `AllowDropRoutine=true`, modified produces comment-only output
- [x] Migration generation (triggers): added uses definition verbatim, empty definition returns error, removed commented-by-default, removed uncommented when `AllowDropTrigger=true`, PostgreSQL DROP includes `ON <table>`, modified produces comment-only output
- [x] End-to-end pipeline: SQLite introspect → diff → migrate correctly identifies trg_legacy (removed) and trg_new (added)
- [x] Full test suite passes; `golangci-lint` clean

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for detecting and diffing changes in stored routines (functions/procedures) and triggers across multiple databases.
  * Added ability to ignore specific routines and triggers during schema comparison.
  * Extended schema introspection to capture routine and trigger metadata.

* **Tests**
  * Added comprehensive test coverage for routine and trigger diffing, introspection, and migration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->