### PR TITLE
release: v1.4.0 — views, routines, triggers, sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-03
+
+### Added
+
+- **View diffing and migration** (issue #100)
+  - Added/removed/modified views tracked in `DiffResult` with full definition comparison
+  - Driver-aware migration generation: `CREATE VIEW`, `DROP VIEW`, `CREATE OR REPLACE VIEW` (PostgreSQL), `CREATE MATERIALIZED VIEW` / `DROP MATERIALIZED VIEW` for materialised views
+  - SQLite view introspection via `sqlite_master`; MySQL via `information_schema.views`; PostgreSQL via `information_schema.views` with `pg_class` for materialised views
+  - `ignore.views` config key to skip named views from diff and migration output
+  - `AllowDropView` migration option (default: `false`) — commented out unless explicitly enabled
+  - Three-way added/removed/modified reporting in both JSON and text output
+
+- **Routine diffing and migration** (issue #101)
+  - Stored procedures and functions tracked in `DiffResult`; diffs across definition, kind (FUNCTION/PROCEDURE), return type, language, and parameters
+  - Driver-aware migration: MySQL `DELIMITER $$` blocks; PostgreSQL `CREATE OR REPLACE FUNCTION`; MSSQL `CREATE OR ALTER PROCEDURE`
+  - Kind badge (FUNCTION / PROCEDURE) on each diff entry
+  - `ignore.routines` config key for exclusion
+  - `AllowDropRoutine` migration option
+
+- **Trigger diffing and migration** (issue #101)
+  - Triggers tracked per table with timing (BEFORE/AFTER/INSTEAD OF), event (INSERT/UPDATE/DELETE), and definition comparison
+  - Migration generation with PostgreSQL ON table syntax and MSSQL/Oracle variants
+  - `ignore.triggers` config key for exclusion
+  - `AllowDropTrigger` migration option
+
+- **Sequence diffing** (issue #102 — PostgreSQL only)
+  - Sequences loaded from `pg_sequences` (PostgreSQL 10+) or `information_schema.sequences` (PostgreSQL <10)
+  - Diff tracks: start value, increment, min/max value, cache size, and cycle flag
+  - `ignore.sequences` config key for exclusion
+  - `AllowDropSequence` migration option
+
+- **HTML report extended with schema objects** (issue #102)
+  - Schema tab now displays Views, Routines, Triggers, and Sequences sections alongside table changes
+  - Each section shows added/removed/modified entries with change descriptions
+  - Schema tab badge counts all object types: tables + views + routines + triggers + sequences
+  - Live sample report hosted at `/samples/report.html` in the documentation site
+
+- **Sample 13 extended** (`samples/13-html-report-viewer/`)
+  - Production and development MySQL schemas now include intentional view, routine, and trigger drift
+  - Added: `v_customer_stats` (new view), `fn_format_price` (new function), `trg_products_updated_at` (new trigger)
+  - Modified: `v_active_orders`, `fn_calculate_total` (added `discount_pct` parameter), `fn_get_customer_tier` (platinum tier), `trg_orders_audit` (logs `status` field)
+  - Removed: `v_customer_summary`
+
+### Fixed
+
+- **MySQL views introspected as tables** — `information_schema.columns` was returning columns for both tables and views; added `JOIN information_schema.tables WHERE table_type = 'BASE TABLE'` to exclude views from the column scan
+- **MySQL view definition false-positive diff** — MySQL embeds the database name in stored view definitions (`` `dbname`.`table` ``); `stripMySQLSchemaPrefix` now strips these prefixes before comparison so prod/dev views with the same logic but different DB names are not reported as modified
+- **HTML report version showing `v0.5`** — generator hardcoded `Version: "v0.5"`; fixed to inject the ldflags `version` variable at both `BuildReportData` call sites in `main.go`
+- **`add` template function arity mismatch** — schema tab badge called `add` with five arguments; template function was defined with fixed arity `(a, b int)`; changed to variadic `func(vals ...int) int`
+- **PostgreSQL `information_schema.sequences` scan error on PG <10** — numeric columns are `character_data` (text) in PG <10; changed to scan as strings and parse with `strconv.ParseInt`
+- **`loadSequences` returning error for MSSQL/Oracle** — non-PostgreSQL drivers now return `nil` instead of an unsupported-driver error
+
+### Tests
+
+- 30 new tests in `tests/schema/routines_triggers_test.go`: `diffRoutines`, `diffTriggers`, SQLite trigger introspection, migration generation
+- Tests for all `diffSequences` modified-field branches (`tests/schema/sequences_test.go`)
+- `writeText` extended with views, routines, triggers, and sequences sections (`tests/schema/sequences_test.go`)
+- Driver-specific migration tests for PostgreSQL, MSSQL, and Oracle branches in `generateModifyColumn`, `generateModifyPrimaryKey`, `generateDropForeignKey`, and `generateDropIndex` (`tests/schema/migrate_drivers_test.go`)
+- HTML report builder tests for `buildViewChanges`, `buildRoutineChanges`, `buildTriggerChanges`, and `buildSequenceChanges` (`tests/html/schema_objects_test.go`)
+- Coverage: `internal/schema` 64% → **70%**; `internal/report/html` 68% → **90%**
+
 ## [1.3.0] - 2026-04-23
 
 ### Added
@@ -422,7 +483,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PostgreSQL schema-aware queries
 - MySQL foreign key check handling
 
-[Unreleased]: https://github.com/iamvirul/deepdiff-db/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/iamvirul/deepdiff-db/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/iamvirul/deepdiff-db/compare/v1.0.0...v1.1.0

--- a/tests/html/schema_objects_test.go
+++ b/tests/html/schema_objects_test.go
@@ -1,0 +1,588 @@
+package html_test
+
+// Coverage tests for buildViewChanges, buildRoutineChanges, buildTriggerChanges,
+// buildSequenceChanges, and the variadic add templateFunc in the HTML report generator.
+
+import (
+	"strings"
+	"testing"
+
+	htmlreport "github.com/iamvirul/deepdiff-db/internal/report/html"
+	"github.com/iamvirul/deepdiff-db/internal/schema"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func emptyDiff() *schema.DiffResult {
+	return &schema.DiffResult{}
+}
+
+func buildWith(diff *schema.DiffResult) *htmlreport.ReportData {
+	return htmlreport.BuildReportData("prod", "dev", diff, nil, nil, nil, nil, "", "", 0, nil)
+}
+
+// ── buildViewChanges ─────────────────────────────────────────────────────────
+
+func TestBuildViewChanges_Added(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedViews: []schema.View{
+			{Name: "v_new_orders", IsMaterialized: false},
+			{Name: "v_mat_view", IsMaterialized: true},
+		},
+	}
+	data := buildWith(diff)
+	if !data.HasViewChanges {
+		t.Fatal("expected HasViewChanges=true")
+	}
+	if len(data.ViewChanges) != 2 {
+		t.Fatalf("expected 2 view changes, got %d", len(data.ViewChanges))
+	}
+	for _, vc := range data.ViewChanges {
+		if vc.ChangeType != "added" {
+			t.Errorf("expected added, got %s", vc.ChangeType)
+		}
+		if !strings.Contains(vc.Description, vc.Name) {
+			t.Errorf("description should contain view name, got %q", vc.Description)
+		}
+		if !strings.Contains(vc.Description, "dev but not in prod") {
+			t.Errorf("description should indicate dev-only, got %q", vc.Description)
+		}
+	}
+	// Verify IsMaterialized is propagated
+	for _, vc := range data.ViewChanges {
+		if vc.Name == "v_mat_view" && !vc.IsMaterialized {
+			t.Error("expected IsMaterialized=true for v_mat_view")
+		}
+		if vc.Name == "v_new_orders" && vc.IsMaterialized {
+			t.Error("expected IsMaterialized=false for v_new_orders")
+		}
+	}
+}
+
+func TestBuildViewChanges_Removed(t *testing.T) {
+	diff := &schema.DiffResult{
+		RemovedViews: []schema.View{
+			{Name: "v_legacy_report", IsMaterialized: false},
+		},
+	}
+	data := buildWith(diff)
+	if len(data.ViewChanges) != 1 {
+		t.Fatalf("expected 1 view change, got %d", len(data.ViewChanges))
+	}
+	vc := data.ViewChanges[0]
+	if vc.ChangeType != "removed" {
+		t.Errorf("expected removed, got %s", vc.ChangeType)
+	}
+	if !strings.Contains(vc.Description, "prod but not in dev") {
+		t.Errorf("description should indicate prod-only, got %q", vc.Description)
+	}
+}
+
+func TestBuildViewChanges_ModifiedDefinitionOnly(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedViews: []schema.ViewDiff{
+			{Name: "v_active_orders", DefinitionDiffers: true, IsMaterializedDiffers: false},
+		},
+	}
+	data := buildWith(diff)
+	if len(data.ViewChanges) != 1 {
+		t.Fatalf("expected 1 view change, got %d", len(data.ViewChanges))
+	}
+	vc := data.ViewChanges[0]
+	if vc.ChangeType != "modified" {
+		t.Errorf("expected modified, got %s", vc.ChangeType)
+	}
+	if !strings.Contains(vc.Description, "View definition changed") {
+		t.Errorf("expected 'View definition changed' in description, got %q", vc.Description)
+	}
+	if strings.Contains(vc.Description, "materialization") {
+		t.Errorf("should not mention materialization when IsMaterializedDiffers=false, got %q", vc.Description)
+	}
+}
+
+func TestBuildViewChanges_ModifiedWithMaterializationChange(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedViews: []schema.ViewDiff{
+			{Name: "v_mat_view", DefinitionDiffers: true, IsMaterializedDiffers: true},
+		},
+	}
+	data := buildWith(diff)
+	if len(data.ViewChanges) != 1 {
+		t.Fatalf("expected 1 view change, got %d", len(data.ViewChanges))
+	}
+	vc := data.ViewChanges[0]
+	if !strings.Contains(vc.Description, "materialization type differs") {
+		t.Errorf("expected materialization mention, got %q", vc.Description)
+	}
+}
+
+func TestBuildViewChanges_SummaryCounts(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedViews:    []schema.View{{Name: "v1"}, {Name: "v2"}},
+		RemovedViews:  []schema.View{{Name: "v3"}},
+		ModifiedViews: []schema.ViewDiff{{Name: "v4", DefinitionDiffers: true}},
+	}
+	data := buildWith(diff)
+	if data.Summary.ViewsChanged != 4 {
+		t.Errorf("expected ViewsChanged=4, got %d", data.Summary.ViewsChanged)
+	}
+}
+
+func TestBuildViewChanges_Empty(t *testing.T) {
+	data := buildWith(emptyDiff())
+	if data.HasViewChanges {
+		t.Error("expected HasViewChanges=false for empty diff")
+	}
+	if len(data.ViewChanges) != 0 {
+		t.Errorf("expected no view changes, got %d", len(data.ViewChanges))
+	}
+}
+
+// ── buildRoutineChanges ──────────────────────────────────────────────────────
+
+func TestBuildRoutineChanges_Added(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedRoutines: []schema.Routine{
+			{Name: "fn_format_price", Kind: "FUNCTION"},
+			{Name: "sp_cleanup_jobs", Kind: "PROCEDURE"},
+		},
+	}
+	data := buildWith(diff)
+	if !data.HasRoutineChanges {
+		t.Fatal("expected HasRoutineChanges=true")
+	}
+	if len(data.RoutineChanges) != 2 {
+		t.Fatalf("expected 2 routine changes, got %d", len(data.RoutineChanges))
+	}
+	for _, rc := range data.RoutineChanges {
+		if rc.ChangeType != "added" {
+			t.Errorf("expected added, got %s", rc.ChangeType)
+		}
+		if rc.IsDestructive {
+			t.Error("added routine should not be destructive")
+		}
+	}
+	// Verify kind is propagated
+	for _, rc := range data.RoutineChanges {
+		if rc.Name == "fn_format_price" && rc.Kind != "FUNCTION" {
+			t.Errorf("expected FUNCTION kind, got %s", rc.Kind)
+		}
+		if rc.Name == "sp_cleanup_jobs" && rc.Kind != "PROCEDURE" {
+			t.Errorf("expected PROCEDURE kind, got %s", rc.Kind)
+		}
+	}
+}
+
+func TestBuildRoutineChanges_Removed(t *testing.T) {
+	diff := &schema.DiffResult{
+		RemovedRoutines: []string{"fn_old_calc", "sp_legacy"},
+	}
+	data := buildWith(diff)
+	if len(data.RoutineChanges) != 2 {
+		t.Fatalf("expected 2 routine changes, got %d", len(data.RoutineChanges))
+	}
+	for _, rc := range data.RoutineChanges {
+		if rc.ChangeType != "removed" {
+			t.Errorf("expected removed, got %s", rc.ChangeType)
+		}
+		if !rc.IsDestructive {
+			t.Error("removed routine should be destructive")
+		}
+	}
+}
+
+func TestBuildRoutineChanges_ModifiedAllFlags(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedRoutines: []schema.RoutineDiff{
+			{
+				Name:              "fn_everything",
+				DefinitionDiffers: true,
+				KindDiffers:       true, ProdKind: "PROCEDURE", DevKind: "FUNCTION",
+				ReturnTypeDiffers: true, ProdReturnType: "INT", DevReturnType: "BIGINT",
+				LanguageDiffers:   true, ProdLanguage: "SQL", DevLanguage: "PLPGSQL",
+				ParametersDiffers: true,
+			},
+		},
+	}
+	data := buildWith(diff)
+	if len(data.RoutineChanges) != 1 {
+		t.Fatalf("expected 1 routine change, got %d", len(data.RoutineChanges))
+	}
+	rc := data.RoutineChanges[0]
+	if rc.ChangeType != "modified" {
+		t.Errorf("expected modified, got %s", rc.ChangeType)
+	}
+	checks := []string{
+		"definition changed",
+		"kind: PROCEDURE -> FUNCTION",
+		"return type: INT -> BIGINT",
+		"language: SQL -> PLPGSQL",
+		"parameters changed",
+	}
+	for _, check := range checks {
+		if !strings.Contains(rc.Description, check) {
+			t.Errorf("expected %q in description, got %q", check, rc.Description)
+		}
+	}
+}
+
+func TestBuildRoutineChanges_ModifiedNoFlags_FallbackDescription(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedRoutines: []schema.RoutineDiff{
+			{Name: "fn_mystery"}, // no flags set
+		},
+	}
+	data := buildWith(diff)
+	if len(data.RoutineChanges) != 1 {
+		t.Fatalf("expected 1 routine change, got %d", len(data.RoutineChanges))
+	}
+	rc := data.RoutineChanges[0]
+	if rc.Description != "Routine modified" {
+		t.Errorf("expected fallback description 'Routine modified', got %q", rc.Description)
+	}
+}
+
+func TestBuildRoutineChanges_SummaryCounts(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedRoutines:    []schema.Routine{{Name: "fn_a"}, {Name: "fn_b"}},
+		RemovedRoutines:  []string{"fn_c"},
+		ModifiedRoutines: []schema.RoutineDiff{{Name: "fn_d", DefinitionDiffers: true}},
+	}
+	data := buildWith(diff)
+	if data.Summary.RoutinesChanged != 4 {
+		t.Errorf("expected RoutinesChanged=4, got %d", data.Summary.RoutinesChanged)
+	}
+}
+
+// ── buildTriggerChanges ──────────────────────────────────────────────────────
+
+func TestBuildTriggerChanges_Added(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedTriggers: []schema.Trigger{
+			{Name: "trg_products_updated_at", Table: "products"},
+			{Name: "trg_orders_notify", Table: "orders"},
+		},
+	}
+	data := buildWith(diff)
+	if !data.HasTriggerChanges {
+		t.Fatal("expected HasTriggerChanges=true")
+	}
+	if len(data.TriggerChanges) != 2 {
+		t.Fatalf("expected 2 trigger changes, got %d", len(data.TriggerChanges))
+	}
+	for _, tc := range data.TriggerChanges {
+		if tc.ChangeType != "added" {
+			t.Errorf("expected added, got %s", tc.ChangeType)
+		}
+		if !strings.Contains(tc.Description, tc.Table) {
+			t.Errorf("description should contain table name, got %q", tc.Description)
+		}
+	}
+}
+
+func TestBuildTriggerChanges_Removed(t *testing.T) {
+	diff := &schema.DiffResult{
+		RemovedTriggers: []string{"trg_legacy_log"},
+	}
+	data := buildWith(diff)
+	if len(data.TriggerChanges) != 1 {
+		t.Fatalf("expected 1 trigger change, got %d", len(data.TriggerChanges))
+	}
+	tc := data.TriggerChanges[0]
+	if tc.ChangeType != "removed" {
+		t.Errorf("expected removed, got %s", tc.ChangeType)
+	}
+	if !tc.IsDestructive {
+		t.Error("removed trigger should be destructive")
+	}
+}
+
+func TestBuildTriggerChanges_ModifiedAllFlags(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedTriggers: []schema.TriggerDiff{
+			{
+				Name:              "trg_orders_audit",
+				TimingDiffers:     true, ProdTiming: "AFTER", DevTiming: "BEFORE",
+				EventDiffers:      true, ProdEvent: "INSERT", DevEvent: "UPDATE",
+				DefinitionDiffers: true,
+			},
+		},
+	}
+	data := buildWith(diff)
+	if len(data.TriggerChanges) != 1 {
+		t.Fatalf("expected 1 trigger change, got %d", len(data.TriggerChanges))
+	}
+	tc := data.TriggerChanges[0]
+	if tc.ChangeType != "modified" {
+		t.Errorf("expected modified, got %s", tc.ChangeType)
+	}
+	checks := []string{
+		"timing: AFTER -> BEFORE",
+		"event: INSERT -> UPDATE",
+		"definition changed",
+	}
+	for _, check := range checks {
+		if !strings.Contains(tc.Description, check) {
+			t.Errorf("expected %q in description, got %q", check, tc.Description)
+		}
+	}
+}
+
+func TestBuildTriggerChanges_ModifiedNoFlags_FallbackDescription(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedTriggers: []schema.TriggerDiff{{Name: "trg_mystery"}},
+	}
+	data := buildWith(diff)
+	if len(data.TriggerChanges) != 1 {
+		t.Fatalf("expected 1 trigger change, got %d", len(data.TriggerChanges))
+	}
+	if data.TriggerChanges[0].Description != "Trigger modified" {
+		t.Errorf("expected fallback 'Trigger modified', got %q", data.TriggerChanges[0].Description)
+	}
+}
+
+func TestBuildTriggerChanges_SummaryCounts(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedTriggers:    []schema.Trigger{{Name: "t1", Table: "a"}, {Name: "t2", Table: "b"}},
+		RemovedTriggers:  []string{"t3"},
+		ModifiedTriggers: []schema.TriggerDiff{{Name: "t4", DefinitionDiffers: true}},
+	}
+	data := buildWith(diff)
+	if data.Summary.TriggersChanged != 4 {
+		t.Errorf("expected TriggersChanged=4, got %d", data.Summary.TriggersChanged)
+	}
+}
+
+// ── buildSequenceChanges ─────────────────────────────────────────────────────
+
+func TestBuildSequenceChanges_Added(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedSequences: []schema.Sequence{
+			{Name: "seq_order_id"},
+			{Name: "seq_invoice_num"},
+		},
+	}
+	data := buildWith(diff)
+	if !data.HasSequenceChanges {
+		t.Fatal("expected HasSequenceChanges=true")
+	}
+	if len(data.SequenceChanges) != 2 {
+		t.Fatalf("expected 2 sequence changes, got %d", len(data.SequenceChanges))
+	}
+	for _, sc := range data.SequenceChanges {
+		if sc.ChangeType != "added" {
+			t.Errorf("expected added, got %s", sc.ChangeType)
+		}
+	}
+}
+
+func TestBuildSequenceChanges_Removed(t *testing.T) {
+	diff := &schema.DiffResult{
+		RemovedSequences: []string{"seq_legacy"},
+	}
+	data := buildWith(diff)
+	if len(data.SequenceChanges) != 1 {
+		t.Fatalf("expected 1 sequence change, got %d", len(data.SequenceChanges))
+	}
+	sc := data.SequenceChanges[0]
+	if sc.ChangeType != "removed" {
+		t.Errorf("expected removed, got %s", sc.ChangeType)
+	}
+	if !strings.Contains(sc.Description, "prod but not in dev") {
+		t.Errorf("description should indicate prod-only, got %q", sc.Description)
+	}
+}
+
+func TestBuildSequenceChanges_ModifiedAllNumericFields(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedSequences: []schema.SequenceDiff{
+			{
+				Name:              "seq_users",
+				StartValueDiffers: true, ProdStartValue: 1, DevStartValue: 1000,
+				IncrementDiffers: true, ProdIncrement: 1, DevIncrement: 10,
+				MinValueDiffers:  true, ProdMinValue: 1, DevMinValue: 100,
+				MaxValueDiffers:  true, ProdMaxValue: 9999, DevMaxValue: 99999,
+				CacheSizeDiffers: true, ProdCacheSize: 1, DevCacheSize: 50,
+			},
+		},
+	}
+	data := buildWith(diff)
+	if len(data.SequenceChanges) != 1 {
+		t.Fatalf("expected 1 sequence change, got %d", len(data.SequenceChanges))
+	}
+	sc := data.SequenceChanges[0]
+	if sc.ChangeType != "modified" {
+		t.Errorf("expected modified, got %s", sc.ChangeType)
+	}
+	checks := []string{
+		"start value: 1 -> 1000",
+		"increment: 1 -> 10",
+		"min value: 1 -> 100",
+		"max value: 9999 -> 99999",
+		"cache size: 1 -> 50",
+	}
+	for _, check := range checks {
+		if !strings.Contains(sc.Description, check) {
+			t.Errorf("expected %q in description, got %q", check, sc.Description)
+		}
+	}
+}
+
+func TestBuildSequenceChanges_ModifiedCycle_TrueToFalse(t *testing.T) {
+	boolTrue := true
+	boolFalse := false
+	diff := &schema.DiffResult{
+		ModifiedSequences: []schema.SequenceDiff{
+			{Name: "seq_cycled", CycleDiffers: true, ProdCycle: &boolTrue, DevCycle: &boolFalse},
+		},
+	}
+	data := buildWith(diff)
+	sc := data.SequenceChanges[0]
+	if !strings.Contains(sc.Description, "cycle: true -> false") {
+		t.Errorf("expected 'cycle: true -> false', got %q", sc.Description)
+	}
+}
+
+func TestBuildSequenceChanges_ModifiedCycle_NilPointers(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedSequences: []schema.SequenceDiff{
+			{Name: "seq_nil_cycle", CycleDiffers: true, ProdCycle: nil, DevCycle: nil},
+		},
+	}
+	data := buildWith(diff)
+	sc := data.SequenceChanges[0]
+	// Both nil → both render as "false"
+	if !strings.Contains(sc.Description, "cycle: false -> false") {
+		t.Errorf("expected 'cycle: false -> false' for nil pointers, got %q", sc.Description)
+	}
+}
+
+func TestBuildSequenceChanges_ModifiedNoFlags_FallbackDescription(t *testing.T) {
+	diff := &schema.DiffResult{
+		ModifiedSequences: []schema.SequenceDiff{{Name: "seq_mystery"}},
+	}
+	data := buildWith(diff)
+	if len(data.SequenceChanges) != 1 {
+		t.Fatalf("expected 1 sequence change, got %d", len(data.SequenceChanges))
+	}
+	if data.SequenceChanges[0].Description != "Sequence modified" {
+		t.Errorf("expected fallback 'Sequence modified', got %q", data.SequenceChanges[0].Description)
+	}
+}
+
+func TestBuildSequenceChanges_SummaryCounts(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedSequences:    []schema.Sequence{{Name: "s1"}, {Name: "s2"}},
+		RemovedSequences:  []string{"s3", "s4"},
+		ModifiedSequences: []schema.SequenceDiff{{Name: "s5", StartValueDiffers: true}},
+	}
+	data := buildWith(diff)
+	if data.Summary.SequencesChanged != 5 {
+		t.Errorf("expected SequencesChanged=5, got %d", data.Summary.SequencesChanged)
+	}
+}
+
+// ── templateFuncs variadic add ───────────────────────────────────────────────
+// The schema tab badge calls add with 5 arguments: len(SchemaChanges) +
+// ViewsChanged + RoutinesChanged + TriggersChanged + SequencesChanged.
+// We verify this via a full GenerateReport call with all change types populated.
+
+func TestGenerateReport_VariadicAddInSchemaBadge(t *testing.T) {
+	diff := &schema.DiffResult{
+		AddedTables: []schema.Table{{Name: "new_tbl"}},
+		AddedViews:  []schema.View{{Name: "v_new"}},
+		AddedRoutines: []schema.Routine{{Name: "fn_new", Kind: "FUNCTION"}},
+		AddedTriggers: []schema.Trigger{{Name: "trg_new", Table: "new_tbl"}},
+		AddedSequences: []schema.Sequence{{Name: "seq_new"}},
+	}
+	data := htmlreport.BuildReportData("prod", "dev", diff, nil, nil, nil, nil, "", "", 1, nil)
+
+	g := htmlreport.NewGenerator(nil)
+	outPath := t.TempDir() + "/report.html"
+	if err := g.GenerateReport(data, outPath); err != nil {
+		t.Fatalf("GenerateReport failed with variadic add: %v", err)
+	}
+}
+
+// ── all object types together in one report ──────────────────────────────────
+
+func TestBuildReportData_AllSchemaObjectTypes(t *testing.T) {
+	boolFalse := false
+	boolTrue := true
+	diff := &schema.DiffResult{
+		// Tables
+		AddedTables:   []schema.Table{{Name: "feature_flags"}},
+		RemovedTables: []string{"legacy_settings"},
+		Tables: []schema.TableDiff{
+			{
+				Name:           "customers",
+				HasDifferences: true,
+				AddedColumns:   []schema.Column{{Name: "tier", DataType: "VARCHAR(20)"}},
+			},
+		},
+		// Views
+		AddedViews:   []schema.View{{Name: "v_customer_stats"}},
+		RemovedViews: []schema.View{{Name: "v_customer_summary"}},
+		ModifiedViews: []schema.ViewDiff{
+			{Name: "v_active_orders", DefinitionDiffers: true, IsMaterializedDiffers: true},
+		},
+		// Routines
+		AddedRoutines:   []schema.Routine{{Name: "fn_format_price", Kind: "FUNCTION"}},
+		RemovedRoutines: []string{"fn_old_calc"},
+		ModifiedRoutines: []schema.RoutineDiff{
+			{Name: "fn_get_tier", DefinitionDiffers: true, ReturnTypeDiffers: true,
+				ProdReturnType: "VARCHAR(10)", DevReturnType: "VARCHAR(20)"},
+		},
+		// Triggers
+		AddedTriggers:   []schema.Trigger{{Name: "trg_updated_at", Table: "products"}},
+		RemovedTriggers: []string{"trg_legacy"},
+		ModifiedTriggers: []schema.TriggerDiff{
+			{Name: "trg_audit", TimingDiffers: true, ProdTiming: "BEFORE", DevTiming: "AFTER"},
+		},
+		// Sequences
+		AddedSequences:   []schema.Sequence{{Name: "seq_orders"}},
+		RemovedSequences: []string{"seq_old"},
+		ModifiedSequences: []schema.SequenceDiff{
+			{Name: "seq_users", CycleDiffers: true, ProdCycle: &boolFalse, DevCycle: &boolTrue},
+		},
+	}
+
+	data := buildWith(diff)
+
+	if !data.HasViewChanges {
+		t.Error("expected HasViewChanges=true")
+	}
+	if !data.HasRoutineChanges {
+		t.Error("expected HasRoutineChanges=true")
+	}
+	if !data.HasTriggerChanges {
+		t.Error("expected HasTriggerChanges=true")
+	}
+	if !data.HasSequenceChanges {
+		t.Error("expected HasSequenceChanges=true")
+	}
+	if !data.HasSchemaDiff {
+		t.Error("expected HasSchemaDiff=true")
+	}
+
+	// Verify summary counts
+	if data.Summary.ViewsChanged != 3 {
+		t.Errorf("expected ViewsChanged=3, got %d", data.Summary.ViewsChanged)
+	}
+	if data.Summary.RoutinesChanged != 3 {
+		t.Errorf("expected RoutinesChanged=3, got %d", data.Summary.RoutinesChanged)
+	}
+	if data.Summary.TriggersChanged != 3 {
+		t.Errorf("expected TriggersChanged=3, got %d", data.Summary.TriggersChanged)
+	}
+	if data.Summary.SequencesChanged != 3 {
+		t.Errorf("expected SequencesChanged=3, got %d", data.Summary.SequencesChanged)
+	}
+
+	// Verify full report renders without error
+	g := htmlreport.NewGenerator(nil)
+	outPath := t.TempDir() + "/full_report.html"
+	if err := g.GenerateReport(data, outPath); err != nil {
+		t.Fatalf("GenerateReport with all object types failed: %v", err)
+	}
+}

--- a/tests/schema/migrate_drivers_test.go
+++ b/tests/schema/migrate_drivers_test.go
@@ -1,0 +1,487 @@
+package schema_test
+
+// Coverage tests targeting driver-specific branches in:
+//   - generateModifyColumn  (postgres nullable/default branches; mssql; oracle)
+//   - generateModifyPrimaryKey (postgres; sqlite)
+//   - generateDropForeignKey   (postgres; sqlite; default)
+//   - generateDropIndex        (postgres/sqlite path; default/unknown driver)
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/iamvirul/deepdiff-db/internal/schema"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func boolRef(b bool) *bool { return &b }
+func strRef(s string) *string { return &s }
+
+func singleModifiedColumnDiff(t *testing.T, diff schema.DiffResult, driver string) string {
+	t.Helper()
+	sql, err := schema.GenerateMigration(diff, driver, nil)
+	if err != nil {
+		t.Fatalf("GenerateMigration(%s) error: %v", driver, err)
+	}
+	return sql
+}
+
+func modifyColDiff(table string, colDiff schema.ColumnDiff) schema.DiffResult {
+	return schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:            table,
+				HasDifferences:  true,
+				ModifiedColumns: []schema.ColumnDiff{colDiff},
+			},
+		},
+	}
+}
+
+// ── generateModifyColumn — PostgreSQL branches ────────────────────────────────
+
+func TestGenerateMigration_Postgres_ModifyColumn_NullableDropNotNull(t *testing.T) {
+	// DevNullable=true → DROP NOT NULL
+	diff := modifyColDiff("users", schema.ColumnDiff{
+		Column:           "email",
+		NullableMismatch: true,
+		DevNullable:      boolRef(true),
+		ProdNullable:     boolRef(false),
+	})
+	sql := singleModifiedColumnDiff(t, diff, "postgresql")
+	if !strings.Contains(sql, "DROP NOT NULL") {
+		t.Errorf("expected DROP NOT NULL for DevNullable=true, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Postgres_ModifyColumn_NullableSetNotNull(t *testing.T) {
+	// DevNullable=false → SET NOT NULL
+	diff := modifyColDiff("users", schema.ColumnDiff{
+		Column:           "email",
+		NullableMismatch: true,
+		DevNullable:      boolRef(false),
+		ProdNullable:     boolRef(true),
+	})
+	sql := singleModifiedColumnDiff(t, diff, "postgres")
+	if !strings.Contains(sql, "SET NOT NULL") {
+		t.Errorf("expected SET NOT NULL for DevNullable=false, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Postgres_ModifyColumn_DefaultMismatch_AddDefault(t *testing.T) {
+	diff := modifyColDiff("products", schema.ColumnDiff{
+		Column:          "discount",
+		DefaultMismatch: true,
+		DevDefault:      strRef("0.00"),
+		TypeMismatch:    false,
+	})
+	sql := singleModifiedColumnDiff(t, diff, "postgresql")
+	if !strings.Contains(sql, "SET DEFAULT 0.00") {
+		t.Errorf("expected SET DEFAULT, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Postgres_ModifyColumn_DefaultMismatch_DropDefault(t *testing.T) {
+	// DevDefault nil → DROP DEFAULT
+	diff := modifyColDiff("products", schema.ColumnDiff{
+		Column:          "discount",
+		DefaultMismatch: true,
+		DevDefault:      nil,
+		TypeMismatch:    false,
+	})
+	sql := singleModifiedColumnDiff(t, diff, "postgresql")
+	if !strings.Contains(sql, "DROP DEFAULT") {
+		t.Errorf("expected DROP DEFAULT when DevDefault=nil, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Postgres_ModifyColumn_TypeAndNullable(t *testing.T) {
+	diff := modifyColDiff("orders", schema.ColumnDiff{
+		Column:           "amount",
+		TypeMismatch:     true,
+		ProdType:         "DECIMAL(10,2)",
+		DevType:          "DECIMAL(12,2)",
+		NullableMismatch: true,
+		DevNullable:      boolRef(true),
+	})
+	sql := singleModifiedColumnDiff(t, diff, "postgresql")
+	if !strings.Contains(sql, "ALTER COLUMN") {
+		t.Errorf("expected ALTER COLUMN, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "DECIMAL(12,2)") {
+		t.Errorf("expected type change, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "DROP NOT NULL") {
+		t.Errorf("expected DROP NOT NULL, got:\n%s", sql)
+	}
+}
+
+// ── generateModifyColumn — MSSQL branches ────────────────────────────────────
+
+func TestGenerateMigration_MSSQL_ModifyColumn_TypeChange(t *testing.T) {
+	diff := modifyColDiff("users", schema.ColumnDiff{
+		Column:       "name",
+		TypeMismatch: true,
+		ProdType:     "NVARCHAR(100)",
+		DevType:      "NVARCHAR(255)",
+		DevNullable:  boolRef(true),
+	})
+	sql := singleModifiedColumnDiff(t, diff, "mssql")
+	if !strings.Contains(sql, "ALTER COLUMN [name] NVARCHAR(255)") {
+		t.Errorf("expected MSSQL ALTER COLUMN with new type, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_MSSQL_ModifyColumn_NullableChange(t *testing.T) {
+	diff := modifyColDiff("orders", schema.ColumnDiff{
+		Column:           "notes",
+		NullableMismatch: true,
+		DevNullable:      boolRef(false), // NOT NULL
+		ProdNullable:     boolRef(true),
+		DevType:          "NVARCHAR(MAX)",
+		ProdType:         "NVARCHAR(MAX)",
+	})
+	sql := singleModifiedColumnDiff(t, diff, "mssql")
+	if !strings.Contains(sql, "NOT NULL") {
+		t.Errorf("expected NOT NULL in MSSQL modify, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_MSSQL_ModifyColumn_DefaultMismatch_WithDevDefault(t *testing.T) {
+	diff := modifyColDiff("products", schema.ColumnDiff{
+		Column:          "status",
+		DefaultMismatch: true,
+		DevDefault:      strRef("'active'"),
+		DevNullable:     boolRef(false),
+		DevType:         "NVARCHAR(20)",
+	})
+	sql := singleModifiedColumnDiff(t, diff, "mssql")
+	// MSSQL emits a comment for DEFAULT changes
+	if !strings.Contains(sql, "MSSQL: to change DEFAULT") {
+		t.Errorf("expected MSSQL DEFAULT comment, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "'active'") {
+		t.Errorf("expected default value in MSSQL comment, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_MSSQL_ModifyColumn_DefaultMismatch_NilDevDefault(t *testing.T) {
+	diff := modifyColDiff("products", schema.ColumnDiff{
+		Column:          "status",
+		DefaultMismatch: true,
+		DevDefault:      nil, // removing default
+		DevNullable:     boolRef(false),
+		DevType:         "NVARCHAR(20)",
+	})
+	sql := singleModifiedColumnDiff(t, diff, "mssql")
+	if !strings.Contains(sql, "MSSQL: to change DEFAULT") {
+		t.Errorf("expected MSSQL DEFAULT comment for nil DevDefault, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_MSSQL_ModifyColumn_NilNullable_FallsBackToNotNull(t *testing.T) {
+	// When both DevNullable and ProdNullable are nil in MSSQL path,
+	// the code defaults to NOT NULL (no error like mysql).
+	diff := modifyColDiff("users", schema.ColumnDiff{
+		Column:       "email",
+		TypeMismatch: true,
+		ProdType:     "NVARCHAR(100)",
+		DevType:      "NVARCHAR(255)",
+		DevNullable:  nil,
+		ProdNullable: nil,
+	})
+	sql := singleModifiedColumnDiff(t, diff, "mssql")
+	if !strings.Contains(sql, "NOT NULL") {
+		t.Errorf("expected NOT NULL fallback for nil nullable in mssql, got:\n%s", sql)
+	}
+}
+
+// ── generateModifyColumn — Oracle branches ───────────────────────────────────
+
+func TestGenerateMigration_Oracle_ModifyColumn_TypeChange(t *testing.T) {
+	diff := modifyColDiff("employees", schema.ColumnDiff{
+		Column:       "salary",
+		TypeMismatch: true,
+		ProdType:     "NUMBER(10,2)",
+		DevType:      "NUMBER(15,2)",
+		DevNullable:  boolRef(false),
+	})
+	sql := singleModifiedColumnDiff(t, diff, "oracle")
+	if !strings.Contains(sql, `MODIFY "salary" NUMBER(15,2)`) {
+		t.Errorf("expected Oracle MODIFY with new type, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Oracle_ModifyColumn_NullableChange(t *testing.T) {
+	diff := modifyColDiff("orders", schema.ColumnDiff{
+		Column:           "notes",
+		NullableMismatch: true,
+		DevNullable:      boolRef(true), // NULL
+		ProdNullable:     boolRef(false),
+		DevType:          "VARCHAR2(4000)",
+		ProdType:         "VARCHAR2(4000)",
+	})
+	sql := singleModifiedColumnDiff(t, diff, "oracle")
+	if !strings.Contains(sql, "NULL") {
+		t.Errorf("expected NULL in Oracle modify, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Oracle_ModifyColumn_DefaultMismatch_WithDevDefault(t *testing.T) {
+	diff := modifyColDiff("products", schema.ColumnDiff{
+		Column:          "status",
+		DefaultMismatch: true,
+		DevDefault:      strRef("'active'"),
+		DevNullable:     boolRef(false),
+		DevType:         "VARCHAR2(20)",
+	})
+	sql := singleModifiedColumnDiff(t, diff, "oracle")
+	if !strings.Contains(sql, "Oracle: to change DEFAULT") {
+		t.Errorf("expected Oracle DEFAULT comment, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "MODIFY") && !strings.Contains(sql, "'active'") {
+		t.Errorf("expected Oracle DEFAULT modify with value, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Oracle_ModifyColumn_DefaultMismatch_NilDevDefault(t *testing.T) {
+	diff := modifyColDiff("products", schema.ColumnDiff{
+		Column:          "status",
+		DefaultMismatch: true,
+		DevDefault:      nil,
+		DevNullable:     boolRef(false),
+		DevType:         "VARCHAR2(20)",
+	})
+	sql := singleModifiedColumnDiff(t, diff, "oracle")
+	if !strings.Contains(sql, "Oracle: to change DEFAULT") {
+		t.Errorf("expected Oracle DEFAULT comment for nil DevDefault, got:\n%s", sql)
+	}
+}
+
+// ── generateModifyPrimaryKey — PostgreSQL ────────────────────────────────────
+
+func TestGenerateMigration_Postgres_ModifyPrimaryKey_Allowed(t *testing.T) {
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "orders",
+				HasDifferences: true,
+				PrimaryKeyDiff: &schema.PrimaryKeyDiff{
+					ProdColumns: []string{"id"},
+					DevColumns:  []string{"id", "tenant_id"},
+				},
+			},
+		},
+	}
+	cfg := &schema.MigrationOptions{AllowModifyPrimaryKey: true}
+	sql, err := schema.GenerateMigration(diff, "postgresql", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "DROP CONSTRAINT") {
+		t.Errorf("expected DROP CONSTRAINT for postgres PK modification, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "ADD PRIMARY KEY") {
+		t.Errorf("expected ADD PRIMARY KEY for postgres PK modification, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Postgres_ModifyPrimaryKey_Blocked(t *testing.T) {
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "orders",
+				HasDifferences: true,
+				PrimaryKeyDiff: &schema.PrimaryKeyDiff{
+					ProdColumns: []string{"id"},
+					DevColumns:  []string{"id", "tenant_id"},
+				},
+			},
+		},
+	}
+	// AllowModifyPrimaryKey = false (default)
+	sql, err := schema.GenerateMigration(diff, "postgresql", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Statements should be commented out
+	if strings.Contains(sql, "DROP CONSTRAINT") && !strings.Contains(sql, "--") {
+		t.Errorf("expected commented-out DROP CONSTRAINT, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Postgres_ModifyPrimaryKey_NoteInOutput(t *testing.T) {
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "users",
+				HasDifferences: true,
+				PrimaryKeyDiff: &schema.PrimaryKeyDiff{
+					ProdColumns: []string{"id"},
+					DevColumns:  []string{"uuid"},
+				},
+			},
+		},
+	}
+	cfg := &schema.MigrationOptions{AllowModifyPrimaryKey: true}
+	sql, err := schema.GenerateMigration(diff, "postgres", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// PostgreSQL path emits a NOTE about replacing constraint name
+	if !strings.Contains(sql, "NOTE") {
+		t.Errorf("expected NOTE about constraint name replacement, got:\n%s", sql)
+	}
+}
+
+// ── generateModifyPrimaryKey — SQLite ────────────────────────────────────────
+
+func TestGenerateMigration_SQLite_ModifyPrimaryKey_RequiresRecreation(t *testing.T) {
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "items",
+				HasDifferences: true,
+				PrimaryKeyDiff: &schema.PrimaryKeyDiff{
+					ProdColumns: []string{"id"},
+					DevColumns:  []string{"uuid"},
+				},
+			},
+		},
+	}
+	cfg := &schema.MigrationOptions{AllowModifyPrimaryKey: true}
+	sql, err := schema.GenerateMigration(diff, "sqlite", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sql, "SQLite limitation") {
+		t.Errorf("expected SQLite limitation comment, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "table recreation") {
+		t.Errorf("expected table recreation mention, got:\n%s", sql)
+	}
+}
+
+// ── generateDropForeignKey — PostgreSQL ──────────────────────────────────────
+
+func TestGenerateMigration_Postgres_DropForeignKey(t *testing.T) {
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "orders",
+				HasDifferences: true,
+				RemovedForeignKeys: []schema.ForeignKey{
+					{
+						Name:              "fk_orders_customer",
+						Columns:           []string{"customer_id"},
+						ReferencedTable:   "customers",
+						ReferencedColumns: []string{"id"},
+					},
+				},
+			},
+		},
+	}
+	cfg := &schema.MigrationOptions{AllowDropForeignKey: true}
+	sql, err := schema.GenerateMigration(diff, "postgresql", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// PostgreSQL uses DROP CONSTRAINT (not DROP FOREIGN KEY like MySQL)
+	if !strings.Contains(sql, "DROP CONSTRAINT") {
+		t.Errorf("expected PostgreSQL DROP CONSTRAINT, got:\n%s", sql)
+	}
+	// MySQL-style DROP FOREIGN KEY syntax should not appear (only in comments is fine)
+	if strings.Contains(sql, "DROP FOREIGN KEY `") {
+		t.Errorf("PostgreSQL should not use MySQL DROP FOREIGN KEY backtick syntax, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_Postgres_DropForeignKey_AliasDriver(t *testing.T) {
+	// Both "postgres" and "postgresql" should produce the same output
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "line_items",
+				HasDifferences: true,
+				RemovedForeignKeys: []schema.ForeignKey{
+					{
+						Name:              "fk_line_items_order",
+						Columns:           []string{"order_id"},
+						ReferencedTable:   "orders",
+						ReferencedColumns: []string{"id"},
+					},
+				},
+			},
+		},
+	}
+	cfg := &schema.MigrationOptions{AllowDropForeignKey: true}
+	sqlPG, err := schema.GenerateMigration(diff, "postgres", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error (postgres): %v", err)
+	}
+	sqlPQL, err := schema.GenerateMigration(diff, "postgresql", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error (postgresql): %v", err)
+	}
+	// Both should use DROP CONSTRAINT (PostgreSQL style, not MySQL DROP FOREIGN KEY)
+	for _, sql := range []string{sqlPG, sqlPQL} {
+		if !strings.Contains(sql, "DROP CONSTRAINT") {
+			t.Errorf("expected DROP CONSTRAINT, got:\n%s", sql)
+		}
+		if strings.Contains(sql, "DROP FOREIGN KEY `") {
+			t.Errorf("should not use MySQL DROP FOREIGN KEY syntax, got:\n%s", sql)
+		}
+	}
+}
+
+// ── generateDropIndex — postgres/sqlite/unknown driver ────────────────────────
+
+func TestGenerateMigration_Postgres_DropIndex(t *testing.T) {
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "users",
+				HasDifferences: true,
+				RemovedIndexes: []schema.Index{
+					{Name: "idx_users_email", Columns: []string{"email"}, IsUnique: false},
+				},
+			},
+		},
+	}
+	cfg := &schema.MigrationOptions{AllowDropIndex: true}
+	sql, err := schema.GenerateMigration(diff, "postgres", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Postgres DROP INDEX does not include ON table (unlike MySQL/MSSQL)
+	if !strings.Contains(sql, `DROP INDEX "idx_users_email";`) {
+		t.Errorf("expected postgres DROP INDEX without ON clause, got:\n%s", sql)
+	}
+	if strings.Contains(sql, " ON ") {
+		t.Errorf("postgres DROP INDEX should not contain ON, got:\n%s", sql)
+	}
+}
+
+func TestGenerateMigration_SQLite_DropIndex(t *testing.T) {
+	diff := schema.DiffResult{
+		Tables: []schema.TableDiff{
+			{
+				Name:           "products",
+				HasDifferences: true,
+				RemovedIndexes: []schema.Index{
+					{Name: "idx_products_sku", Columns: []string{"sku"}, IsUnique: true},
+				},
+			},
+		},
+	}
+	cfg := &schema.MigrationOptions{AllowDropIndex: true}
+	sql, err := schema.GenerateMigration(diff, "sqlite", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// SQLite DROP INDEX also does not include ON table
+	if !strings.Contains(sql, "DROP INDEX") {
+		t.Errorf("expected DROP INDEX for sqlite, got:\n%s", sql)
+	}
+}

--- a/tests/schema/sequences_test.go
+++ b/tests/schema/sequences_test.go
@@ -1,0 +1,382 @@
+package schema_test
+
+// Tests for Phase 4: Sequences — diffSequences logic and writeText output.
+// Also covers utility functions containsString and stripMySQLSchemaPrefix
+// (exported via public wrappers is not available, so we exercise them
+// indirectly through DiffSchemas / WriteReports which call them internally).
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamvirul/deepdiff-db/internal/schema"
+)
+
+// ── diffSequences — via DiffSchemas ──────────────────────────────────────────
+
+func makeSeqSchema(seqs map[string]schema.Sequence) *schema.Schema {
+	return &schema.Schema{
+		Tables:    map[string]schema.Table{},
+		Sequences: seqs,
+	}
+}
+
+func TestDiffSequences_BothEmpty(t *testing.T) {
+	result := schema.DiffSchemas(makeSeqSchema(nil), makeSeqSchema(nil))
+	if len(result.AddedSequences) != 0 || len(result.RemovedSequences) != 0 || len(result.ModifiedSequences) != 0 {
+		t.Errorf("expected no sequence diffs, got added=%d removed=%d modified=%d",
+			len(result.AddedSequences), len(result.RemovedSequences), len(result.ModifiedSequences))
+	}
+}
+
+func TestDiffSequences_Added(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{})
+	dev := makeSeqSchema(map[string]schema.Sequence{
+		"seq_order_id": {Name: "seq_order_id", StartValue: 1, Increment: 1, MinValue: 1, MaxValue: 9999999},
+	})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedSequences) != 1 {
+		t.Fatalf("expected 1 added sequence, got %d", len(result.AddedSequences))
+	}
+	if result.AddedSequences[0].Name != "seq_order_id" {
+		t.Errorf("expected seq_order_id, got %s", result.AddedSequences[0].Name)
+	}
+	if len(result.RemovedSequences) != 0 || len(result.ModifiedSequences) != 0 {
+		t.Error("expected no removed/modified sequences")
+	}
+}
+
+func TestDiffSequences_Removed(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{
+		"seq_legacy": {Name: "seq_legacy", StartValue: 100, Increment: 10},
+	})
+	dev := makeSeqSchema(map[string]schema.Sequence{})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.RemovedSequences) != 1 {
+		t.Fatalf("expected 1 removed sequence, got %d", len(result.RemovedSequences))
+	}
+	if result.RemovedSequences[0] != "seq_legacy" {
+		t.Errorf("expected seq_legacy, got %s", result.RemovedSequences[0])
+	}
+}
+
+func TestDiffSequences_Identical(t *testing.T) {
+	seq := schema.Sequence{Name: "seq_users", StartValue: 1, Increment: 1, MinValue: 1, MaxValue: 2147483647, CacheSize: 1, Cycle: false}
+	prod := makeSeqSchema(map[string]schema.Sequence{"seq_users": seq})
+	dev := makeSeqSchema(map[string]schema.Sequence{"seq_users": seq})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 0 {
+		t.Errorf("expected no modified sequences for identical sequences, got %d", len(result.ModifiedSequences))
+	}
+}
+
+func TestDiffSequences_ModifiedStartValue(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{
+		"seq_a": {Name: "seq_a", StartValue: 1},
+	})
+	dev := makeSeqSchema(map[string]schema.Sequence{
+		"seq_a": {Name: "seq_a", StartValue: 100},
+	})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 1 {
+		t.Fatalf("expected 1 modified sequence, got %d", len(result.ModifiedSequences))
+	}
+	sd := result.ModifiedSequences[0]
+	if !sd.StartValueDiffers {
+		t.Error("expected StartValueDiffers=true")
+	}
+	if sd.ProdStartValue != 1 || sd.DevStartValue != 100 {
+		t.Errorf("expected prod=1 dev=100, got prod=%d dev=%d", sd.ProdStartValue, sd.DevStartValue)
+	}
+}
+
+func TestDiffSequences_ModifiedIncrement(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{"seq_b": {Name: "seq_b", Increment: 1}})
+	dev := makeSeqSchema(map[string]schema.Sequence{"seq_b": {Name: "seq_b", Increment: 5}})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 1 || !result.ModifiedSequences[0].IncrementDiffers {
+		t.Error("expected IncrementDiffers=true")
+	}
+	sd := result.ModifiedSequences[0]
+	if sd.ProdIncrement != 1 || sd.DevIncrement != 5 {
+		t.Errorf("expected prod=1 dev=5, got prod=%d dev=%d", sd.ProdIncrement, sd.DevIncrement)
+	}
+}
+
+func TestDiffSequences_ModifiedMinValue(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{"seq_c": {Name: "seq_c", MinValue: 1}})
+	dev := makeSeqSchema(map[string]schema.Sequence{"seq_c": {Name: "seq_c", MinValue: 100}})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 1 || !result.ModifiedSequences[0].MinValueDiffers {
+		t.Error("expected MinValueDiffers=true")
+	}
+}
+
+func TestDiffSequences_ModifiedMaxValue(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{"seq_d": {Name: "seq_d", MaxValue: 9999}})
+	dev := makeSeqSchema(map[string]schema.Sequence{"seq_d": {Name: "seq_d", MaxValue: 99999}})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 1 || !result.ModifiedSequences[0].MaxValueDiffers {
+		t.Error("expected MaxValueDiffers=true")
+	}
+	sd := result.ModifiedSequences[0]
+	if sd.ProdMaxValue != 9999 || sd.DevMaxValue != 99999 {
+		t.Errorf("expected prod=9999 dev=99999, got prod=%d dev=%d", sd.ProdMaxValue, sd.DevMaxValue)
+	}
+}
+
+func TestDiffSequences_ModifiedCacheSize(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{"seq_e": {Name: "seq_e", CacheSize: 1}})
+	dev := makeSeqSchema(map[string]schema.Sequence{"seq_e": {Name: "seq_e", CacheSize: 20}})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 1 || !result.ModifiedSequences[0].CacheSizeDiffers {
+		t.Error("expected CacheSizeDiffers=true")
+	}
+	sd := result.ModifiedSequences[0]
+	if sd.ProdCacheSize != 1 || sd.DevCacheSize != 20 {
+		t.Errorf("expected prod=1 dev=20, got prod=%d dev=%d", sd.ProdCacheSize, sd.DevCacheSize)
+	}
+}
+
+func TestDiffSequences_ModifiedCycle(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{"seq_f": {Name: "seq_f", Cycle: false}})
+	dev := makeSeqSchema(map[string]schema.Sequence{"seq_f": {Name: "seq_f", Cycle: true}})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 1 || !result.ModifiedSequences[0].CycleDiffers {
+		t.Error("expected CycleDiffers=true")
+	}
+	sd := result.ModifiedSequences[0]
+	if sd.ProdCycle == nil || *sd.ProdCycle != false {
+		t.Error("expected ProdCycle=false")
+	}
+	if sd.DevCycle == nil || *sd.DevCycle != true {
+		t.Error("expected DevCycle=true")
+	}
+}
+
+func TestDiffSequences_ModifiedMultipleFields(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{
+		"seq_multi": {Name: "seq_multi", StartValue: 1, Increment: 1, MinValue: 1, MaxValue: 1000, CacheSize: 1, Cycle: false},
+	})
+	dev := makeSeqSchema(map[string]schema.Sequence{
+		"seq_multi": {Name: "seq_multi", StartValue: 10, Increment: 5, MinValue: 10, MaxValue: 9999, CacheSize: 50, Cycle: true},
+	})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.ModifiedSequences) != 1 {
+		t.Fatalf("expected 1 modified sequence, got %d", len(result.ModifiedSequences))
+	}
+	sd := result.ModifiedSequences[0]
+	if !sd.StartValueDiffers {
+		t.Error("expected StartValueDiffers")
+	}
+	if !sd.IncrementDiffers {
+		t.Error("expected IncrementDiffers")
+	}
+	if !sd.MinValueDiffers {
+		t.Error("expected MinValueDiffers")
+	}
+	if !sd.MaxValueDiffers {
+		t.Error("expected MaxValueDiffers")
+	}
+	if !sd.CacheSizeDiffers {
+		t.Error("expected CacheSizeDiffers")
+	}
+	if !sd.CycleDiffers {
+		t.Error("expected CycleDiffers")
+	}
+}
+
+func TestDiffSequences_MultipleAddedRemovedModified(t *testing.T) {
+	prod := makeSeqSchema(map[string]schema.Sequence{
+		"seq_keep":   {Name: "seq_keep", Increment: 1},
+		"seq_remove": {Name: "seq_remove", Increment: 1},
+		"seq_modify": {Name: "seq_modify", StartValue: 1},
+	})
+	dev := makeSeqSchema(map[string]schema.Sequence{
+		"seq_keep":   {Name: "seq_keep", Increment: 1},
+		"seq_add":    {Name: "seq_add", Increment: 10},
+		"seq_modify": {Name: "seq_modify", StartValue: 999},
+	})
+	result := schema.DiffSchemas(prod, dev)
+	if len(result.AddedSequences) != 1 || result.AddedSequences[0].Name != "seq_add" {
+		t.Errorf("expected 1 added seq_add, got %v", result.AddedSequences)
+	}
+	if len(result.RemovedSequences) != 1 || result.RemovedSequences[0] != "seq_remove" {
+		t.Errorf("expected 1 removed seq_remove, got %v", result.RemovedSequences)
+	}
+	if len(result.ModifiedSequences) != 1 || result.ModifiedSequences[0].Name != "seq_modify" {
+		t.Errorf("expected 1 modified seq_modify, got %v", result.ModifiedSequences)
+	}
+}
+
+// ── writeText — views/routines/triggers/sequences sections ───────────────────
+
+func TestWriteText_ViewsSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	result := schema.DiffResult{
+		AddedViews: []schema.View{
+			{Name: "v_new_report", Definition: "SELECT 1", IsMaterialized: false},
+		},
+		RemovedViews: []schema.View{
+			{Name: "v_legacy_summary", Definition: "SELECT 2"},
+		},
+		ModifiedViews: []schema.ViewDiff{
+			{Name: "v_active_orders", DefinitionDiffers: true},
+			{Name: "v_mat_orders", IsMaterializedDiffers: true},
+		},
+	}
+	if err := schema.WriteReports(result, tmpDir); err != nil {
+		t.Fatalf("WriteReports: %v", err)
+	}
+	txt := readTextReport(t, tmpDir)
+	assertContains(t, txt, "View: v_new_report [added]")
+	assertContains(t, txt, "View: v_legacy_summary [removed]")
+	assertContains(t, txt, "View: v_active_orders [modified]")
+	assertContains(t, txt, "definition differs")
+	assertContains(t, txt, "View: v_mat_orders [modified]")
+	assertContains(t, txt, "materialized differs")
+}
+
+func TestWriteText_RoutinesSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	result := schema.DiffResult{
+		AddedRoutines: []schema.Routine{
+			{Name: "fn_format_price", Kind: "FUNCTION"},
+			{Name: "sp_cleanup", Kind: "PROCEDURE"},
+		},
+		RemovedRoutines: []string{"fn_old_calc"},
+		ModifiedRoutines: []schema.RoutineDiff{
+			{Name: "fn_calculate_total", DefinitionDiffers: true},
+			{Name: "fn_tier_check", KindDiffers: true, ProdKind: "PROCEDURE", DevKind: "FUNCTION"},
+			{Name: "fn_price", ReturnTypeDiffers: true, ProdReturnType: "DECIMAL(10,2)", DevReturnType: "DECIMAL(12,2)"},
+			{Name: "fn_lang", LanguageDiffers: true, ProdLanguage: "SQL", DevLanguage: "PLPGSQL"},
+			{Name: "fn_params", ParametersDiffers: true},
+		},
+	}
+	if err := schema.WriteReports(result, tmpDir); err != nil {
+		t.Fatalf("WriteReports: %v", err)
+	}
+	txt := readTextReport(t, tmpDir)
+	assertContains(t, txt, "Routine (FUNCTION): fn_format_price [added]")
+	assertContains(t, txt, "Routine (PROCEDURE): sp_cleanup [added]")
+	assertContains(t, txt, "Routine: fn_old_calc [removed]")
+	assertContains(t, txt, "Routine: fn_calculate_total [modified]")
+	assertContains(t, txt, "definition differs")
+	assertContains(t, txt, "Routine: fn_tier_check [modified]")
+	assertContains(t, txt, "kind differs: prod=PROCEDURE dev=FUNCTION")
+	assertContains(t, txt, "Routine: fn_price [modified]")
+	assertContains(t, txt, "return type differs: prod=DECIMAL(10,2) dev=DECIMAL(12,2)")
+	assertContains(t, txt, "Routine: fn_lang [modified]")
+	assertContains(t, txt, "language differs: prod=SQL dev=PLPGSQL")
+	assertContains(t, txt, "Routine: fn_params [modified]")
+	assertContains(t, txt, "parameters differ")
+}
+
+func TestWriteText_TriggersSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	result := schema.DiffResult{
+		AddedTriggers: []schema.Trigger{
+			{Name: "trg_products_updated_at", Table: "products", Timing: "BEFORE", Event: "UPDATE"},
+		},
+		RemovedTriggers: []string{"trg_legacy_audit"},
+		ModifiedTriggers: []schema.TriggerDiff{
+			{Name: "trg_orders_audit", DefinitionDiffers: true},
+			{Name: "trg_timing_change", TimingDiffers: true, ProdTiming: "AFTER", DevTiming: "BEFORE"},
+			{Name: "trg_event_change", EventDiffers: true, ProdEvent: "INSERT", DevEvent: "UPDATE"},
+		},
+	}
+	if err := schema.WriteReports(result, tmpDir); err != nil {
+		t.Fatalf("WriteReports: %v", err)
+	}
+	txt := readTextReport(t, tmpDir)
+	assertContains(t, txt, "Trigger: trg_products_updated_at (table: products) [added]")
+	assertContains(t, txt, "Trigger: trg_legacy_audit [removed]")
+	assertContains(t, txt, "Trigger: trg_orders_audit [modified]")
+	assertContains(t, txt, "definition differs")
+	assertContains(t, txt, "Trigger: trg_timing_change [modified]")
+	assertContains(t, txt, "timing differs: prod=AFTER dev=BEFORE")
+	assertContains(t, txt, "Trigger: trg_event_change [modified]")
+	assertContains(t, txt, "event differs: prod=INSERT dev=UPDATE")
+}
+
+func TestWriteText_SequencesSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	boolTrue := true
+	boolFalse := false
+	result := schema.DiffResult{
+		AddedSequences: []schema.Sequence{
+			{Name: "seq_new_orders", StartValue: 1, Increment: 1},
+		},
+		RemovedSequences: []string{"seq_legacy_ids"},
+		ModifiedSequences: []schema.SequenceDiff{
+			{
+				Name:              "seq_users",
+				StartValueDiffers: true, ProdStartValue: 1, DevStartValue: 1000,
+				IncrementDiffers: true, ProdIncrement: 1, DevIncrement: 5,
+				MinValueDiffers: true, ProdMinValue: 1, DevMinValue: 10,
+				MaxValueDiffers: true, ProdMaxValue: 9999, DevMaxValue: 99999,
+				CacheSizeDiffers: true, ProdCacheSize: 1, DevCacheSize: 20,
+				CycleDiffers: true, ProdCycle: &boolFalse, DevCycle: &boolTrue,
+			},
+		},
+	}
+	if err := schema.WriteReports(result, tmpDir); err != nil {
+		t.Fatalf("WriteReports: %v", err)
+	}
+	txt := readTextReport(t, tmpDir)
+	assertContains(t, txt, "Sequence: seq_new_orders [added]")
+	assertContains(t, txt, "Sequence: seq_legacy_ids [removed]")
+	assertContains(t, txt, "Sequence: seq_users [modified]")
+	assertContains(t, txt, "start value differs: prod=1 dev=1000")
+	assertContains(t, txt, "increment differs: prod=1 dev=5")
+	assertContains(t, txt, "min value differs: prod=1 dev=10")
+	assertContains(t, txt, "max value differs: prod=9999 dev=99999")
+	assertContains(t, txt, "cache size differs: prod=1 dev=20")
+	assertContains(t, txt, "cycle differs:")
+}
+
+func TestWriteText_AllObjectTypesNoTableChanges(t *testing.T) {
+	// Verify "Schema: OK" is NOT written when there are only view/routine/trigger changes
+	tmpDir := t.TempDir()
+	result := schema.DiffResult{
+		AddedViews: []schema.View{{Name: "v_new", Definition: "SELECT 1"}},
+	}
+	if err := schema.WriteReports(result, tmpDir); err != nil {
+		t.Fatalf("WriteReports: %v", err)
+	}
+	txt := readTextReport(t, tmpDir)
+	if strings.Contains(txt, "Schema: OK") {
+		t.Error("should not write 'Schema: OK' when there are view changes")
+	}
+	assertContains(t, txt, "View: v_new [added]")
+}
+
+func TestWriteText_OKWhenNothingChanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	result := schema.DiffResult{}
+	if err := schema.WriteReports(result, tmpDir); err != nil {
+		t.Fatalf("WriteReports: %v", err)
+	}
+	txt := readTextReport(t, tmpDir)
+	assertContains(t, txt, "Schema: OK (no differences)")
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func readTextReport(t *testing.T, dir string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(dir, "schema_diff.txt"))
+	if err != nil {
+		t.Fatalf("read schema_diff.txt: %v", err)
+	}
+	return string(content)
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected text to contain %q\ngot:\n%s", needle, haystack)
+	}
+}

--- a/website/docs/commands/schema-diff.md
+++ b/website/docs/commands/schema-diff.md
@@ -14,6 +14,7 @@ deepdiffdb schema-diff --config deepdiffdb.config.yaml
 
 ## What It Checks
 
+**Tables**
 - **Added tables** — tables that exist in dev but not in prod
 - **Removed tables** — tables that exist in prod but not in dev
 - **Column changes** — per-column: data type, nullability, default value, column order
@@ -22,7 +23,13 @@ deepdiffdb schema-diff --config deepdiffdb.config.yaml
 - **Index changes** — added, removed, or modified indexes (unique/non-unique)
 - **Foreign key changes** — added or removed FK constraints
 
-Tables listed in `ignore.tables` are excluded entirely.
+**Schema objects**
+- **Views** — added, removed, and modified views; materialised view flag changes (PostgreSQL)
+- **Routines** — added, removed, and modified stored procedures and functions; detects definition, kind, return type, language, and parameter changes
+- **Triggers** — added, removed, and modified triggers; detects timing (BEFORE/AFTER/INSTEAD OF), event (INSERT/UPDATE/DELETE), and definition changes
+- **Sequences** — added, removed, and modified sequences (PostgreSQL only); tracks start value, increment, min/max value, cache size, and cycle flag
+
+Tables listed in `ignore.tables` are excluded entirely. Use `ignore.views`, `ignore.routines`, `ignore.triggers`, and `ignore.sequences` to exclude specific schema objects by name.
 
 ## Flags
 

--- a/website/docs/deployment/cicd.md
+++ b/website/docs/deployment/cicd.md
@@ -162,7 +162,7 @@ DeepDiff DB ships a `.pre-commit-hooks.yaml` at the repo root, so you can refere
 ```yaml
 repos:
   - repo: https://github.com/iamvirul/deepdiff-db
-    rev: v1.3.0   # pin to a release tag
+    rev: v1.4.0   # pin to a release tag
     hooks:
       - id: deepdiff-db-schema
         # Optional: override the config path
@@ -215,7 +215,7 @@ jobs:
 
 ## Tips
 
-- **Pin the version** with `DEEPDIFFDB_VERSION: v1.3.0` to avoid unexpected upgrades.
+- **Pin the version** with `DEEPDIFFDB_VERSION: v1.4.0` to avoid unexpected upgrades.
 - **Cache the binary** between runs using your CI platform's cache action.
 - **Silent schema gate** — use `schema-diff --quiet` for a fully silent check; exit code `0` = no drift, non-zero = drift or error.
 - **Temporary output dirs** — use `--output-dir /tmp/deepdiff-$$` so ephemeral runners don't need a writable workspace.

--- a/website/docs/deployment/docker.md
+++ b/website/docs/deployment/docker.md
@@ -13,7 +13,7 @@ DeepDiff DB ships a minimal, scratch-based Docker image with zero native depende
 docker pull ghcr.io/iamvirul/deepdiff-db:latest
 
 # Specific version
-docker pull ghcr.io/iamvirul/deepdiff-db:v1.3.0
+docker pull ghcr.io/iamvirul/deepdiff-db:v1.4.0
 ```
 
 ## Run a diff
@@ -52,8 +52,8 @@ Copy and adapt `docker-compose.example.yml` to point at your real databases.
 
 ```bash
 docker build \
-  --build-arg VERSION=v1.3.0 \
-  -t deepdiff-db:v1.3.0 \
+  --build-arg VERSION=v1.4.0 \
+  -t deepdiff-db:v1.4.0 \
   .
 ```
 
@@ -70,8 +70,8 @@ The multi-stage build compiles a statically linked binary with `CGO_ENABLED=0`, 
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `v1.3.0` | Specific version |
-| `v1.3.0-amd64` | Architecture-specific manifest |
-| `v1.3.0-arm64` | Architecture-specific manifest |
+| `v1.4.0` | Specific version |
+| `v1.4.0-amd64` | Architecture-specific manifest |
+| `v1.4.0-arm64` | Architecture-specific manifest |
 
 Multi-arch manifests cover `linux/amd64` and `linux/arm64`.

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -179,6 +179,23 @@ The `ignore.columns` list supports two forms:
 
 Ignored columns are excluded from row hashing, so changes to those columns will not appear as conflicts or data differences.
 
+```yaml
+ignore:
+  tables:
+    - "audit_logs"
+  columns:
+    - "*.updated_at"
+    - "*.created_at"
+  views:
+    - "v_legacy_report"     # exact view name to skip
+  routines:
+    - "fn_debug_helper"     # exact routine name to skip
+  triggers:
+    - "trg_old_logging"     # exact trigger name to skip
+  sequences:
+    - "seq_deprecated"      # exact sequence name to skip (PostgreSQL only)
+```
+
 ## Migration Safety Controls
 
 By default all destructive DDL operations are blocked. When `schema-migrate` or `gen-pack` encounters a blocked operation it emits a warning and comments out the statement in the generated SQL. Set the relevant flag to `true` to allow the operation to be generated as executable SQL.
@@ -190,6 +207,10 @@ By default all destructive DDL operations are blocked. When `schema-migrate` or 
 | `allow_drop_index` | `DROP INDEX` |
 | `allow_drop_foreign_key` | `DROP FOREIGN KEY` / `DROP CONSTRAINT` |
 | `allow_modify_primary_key` | `DROP PRIMARY KEY` + `ADD PRIMARY KEY` |
+| `allow_drop_view` | `DROP VIEW` / `DROP MATERIALIZED VIEW` |
+| `allow_drop_routine` | `DROP FUNCTION` / `DROP PROCEDURE` |
+| `allow_drop_trigger` | `DROP TRIGGER` |
+| `allow_drop_sequence` | `DROP SEQUENCE` (PostgreSQL only) |
 
 ## Conflict Resolution Strategies
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -148,7 +148,7 @@ deepdiffdb --version
 Expected output:
 
 ```
-DeepDiff DB v1.3.0
+DeepDiff DB v1.4.0
 ```
 
 ---

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -10,7 +10,7 @@ DeepDiff DB is a high-performance Go CLI tool for comparing two databases, detec
 ## Feature Highlights
 
 - **Multi-database support** — MySQL, PostgreSQL, SQLite, Microsoft SQL Server, and Oracle Database
-- **Schema drift detection** — Detects added/removed tables, column type changes, nullability, defaults, indexes, and foreign keys
+- **Schema drift detection** — Detects added/removed tables, column type changes, nullability, defaults, indexes, foreign keys, views, stored procedures, functions, triggers, and sequences (PostgreSQL)
 - **Row-level diffing** — SHA-256 hashing per row for accurate change detection across any table size
 - **Conflict detection** — Identifies rows that exist in both databases with differing values, before any write
 - **Safe migration generation** — Produces transactional SQL packs reviewable before apply; destructive operations are off by default

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -131,7 +131,7 @@ export default function Home() {
       <div className={styles.hero}>
         <div className={styles.heroBg} />
         <div className={styles.heroContent}>
-          <div className={styles.heroBadge}>v1.3 — CI/CD Integration</div>
+          <div className={styles.heroBadge}>v1.4 — Views, Routines, Triggers &amp; Sequences</div>
           <h1 className={styles.heroTitle}>
             Database diff that<br />
             <span className={styles.heroGradient}>actually ships</span>


### PR DESCRIPTION
## Summary

- **v1.4.0 release preparation** — all Phase 1-4 work from issues #99-#102 (schema model foundation → views → routines/triggers → sequences + HTML report extensions)
- CHANGELOG.md updated with full v1.4.0 entry
- Website docs updated: version bump (1.3.0 → 1.4.0), new `ignore.views/routines/triggers/sequences` config keys, `allow_drop_view/routine/trigger/sequence` migration safety controls, updated feature descriptions
- Test coverage improved: `internal/schema` 64% → 70%; `internal/report/html` 68% → 90%

## New test files

| File | Tests added |
|---|---|
| `tests/schema/sequences_test.go` | `diffSequences` all 6 modified-field branches; `writeText` views/routines/triggers/sequences sections |
| `tests/schema/migrate_drivers_test.go` | PostgreSQL nullable/default column modify; MSSQL/Oracle modify-column; PostgreSQL and SQLite PK modification; PostgreSQL FK drop; postgres/sqlite DROP INDEX |
| `tests/html/schema_objects_test.go` | `buildViewChanges`, `buildRoutineChanges`, `buildTriggerChanges`, `buildSequenceChanges` (all branches including fallback descriptions and nil cycle pointers); variadic `add` via full render |

## Documentation changes

- `intro.md` — schema drift detection bullet updated to include views, routines, triggers, sequences
- `commands/schema-diff.md` — What It Checks section extended with schema objects section
- `getting-started/configuration.md` — ignore config example expanded; migration safety controls table extended with 4 new allow_drop_* keys
- `deployment/docker.md`, `deployment/cicd.md`, `getting-started/installation.md` — version bump to v1.4.0

## Test plan

- [x] All tests pass: `go test ./tests/... ./internal/... ./pkg/...`
- [x] Docusaurus site builds without broken links: `npm run build` in `website/`
- [x] Coverage verified locally: schema 70%, html/report 90%