### PR TITLE
fix(ci): remove inline heredoc to fix YAML syntax error on L184

### DIFF
--- a/.github/windows-installer/readme.txt
+++ b/.github/windows-installer/readme.txt
@@ -1,0 +1,26 @@
+DeepDiff DB - Quick Start
+=========================
+
+After installation, open a new Command Prompt or PowerShell window and run:
+
+    deepdiffdb --version
+
+Create a config file:
+
+    deepdiffdb init
+
+Run your first diff:
+
+    deepdiffdb diff --html
+
+Supported Databases
+-------------------
+  MySQL, PostgreSQL, SQLite, Microsoft SQL Server, Oracle Database
+
+Documentation
+-------------
+  https://iamvirul.github.io/deepdiff-db/
+
+Source Code
+-----------
+  https://github.com/iamvirul/deepdiff-db

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,38 +189,9 @@ jobs:
           sed "s/__APP_VERSION__/${VER_CLEAN}/g" \
             .github/windows-installer.nsi > installer.nsi
 
-          # MUI2 README page — must exist at makensis compile time.
-          # Plain text is sufficient; MUI2 renders it in a scrollable text box.
-          # <<-'EOF' strips leading tabs so YAML indentation doesn't bleed into
-          # the generated file; content lines below are indented with tabs.
-          cat > readme.txt <<-'EOF'
-					DeepDiff DB - Quick Start
-					=========================
-
-					After installation, open a new Command Prompt or PowerShell window and run:
-
-					    deepdiffdb --version
-
-					Create a config file:
-
-					    deepdiffdb init
-
-					Run your first diff:
-
-					    deepdiffdb diff --html
-
-					Supported Databases
-					-------------------
-					  MySQL, PostgreSQL, SQLite, Microsoft SQL Server, Oracle Database
-
-					Documentation
-					-------------
-					  https://iamvirul.github.io/deepdiff-db/
-
-					Source Code
-					-----------
-					  https://github.com/iamvirul/deepdiff-db
-					EOF
+          # MUI2 README page — copy the static file tracked in the repo.
+          # Avoids inline heredocs which are error-prone inside YAML run blocks.
+          cp .github/windows-installer/readme.txt readme.txt
 
           echo "INSTALLER_NAME=deepdiff-db-${VERSION}-windows-amd64-installer.exe" \
             >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

The `<<-'EOF'` heredoc inside the `run: |` block of the **Prepare NSIS script and resources** step caused a YAML parse error at line 184. Inline heredocs are unreliable in YAML `run` blocks — tabs, blank lines, and the `EOF` terminator all interact badly with the YAML parser.

## Fix

Move the `readme.txt` content out of the workflow entirely. It now lives as a static tracked file at `.github/windows-installer/readme.txt`. The workflow step simply does:

```bash
cp .github/windows-installer/readme.txt readme.txt
```

No heredoc, no YAML parsing issue, content is version-controlled and easy to update.

## No behaviour change

The file content is identical to what the heredoc was generating. MUI2 still picks it up at `makensis` compile time.