### PR TITLE
fix(macos-installer): dark mode code styling and Gatekeeper signing

### DIFF
--- a/.github/macos-installer/conclusion.html
+++ b/.github/macos-installer/conclusion.html
@@ -3,30 +3,37 @@
 <head>
 <meta charset="utf-8"/>
 <style>
+  :root {
+    color-scheme: light dark;
+    --code-bg: rgba(0, 0, 0, 0.07);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --code-bg: rgba(255, 255, 255, 0.12); }
+  }
   body {
     font-family: -apple-system, Helvetica Neue, sans-serif;
     font-size: 13px;
-    color: #1d1d1f;
+    color: -apple-system-label;
     margin: 20px 24px;
     line-height: 1.5;
   }
   h2 { font-size: 17px; font-weight: 600; margin: 0 0 10px; }
   p  { margin: 0 0 10px; }
   code {
-    background: #f2f2f7;
+    background: var(--code-bg);
     border-radius: 4px;
     padding: 1px 5px;
     font-size: 12px;
     font-family: "SF Mono", Menlo, monospace;
   }
   pre {
-    background: #f2f2f7;
+    background: var(--code-bg);
     border-radius: 6px;
     padding: 10px 12px;
     font-size: 12px;
     font-family: "SF Mono", Menlo, monospace;
   }
-  a { color: #0066cc; }
+  a { color: -apple-system-blue; }
 </style>
 </head>
 <body>

--- a/.github/macos-installer/readme.html
+++ b/.github/macos-installer/readme.html
@@ -3,10 +3,17 @@
 <head>
 <meta charset="utf-8"/>
 <style>
+  :root {
+    color-scheme: light dark;
+    --code-bg: rgba(0, 0, 0, 0.07);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --code-bg: rgba(255, 255, 255, 0.12); }
+  }
   body {
     font-family: -apple-system, Helvetica Neue, sans-serif;
     font-size: 13px;
-    color: #1d1d1f;
+    color: -apple-system-label;
     margin: 20px 24px;
     line-height: 1.5;
   }
@@ -16,21 +23,21 @@
   ul { margin: 0 0 10px; padding-left: 20px; }
   li { margin-bottom: 4px; }
   code {
-    background: #f2f2f7;
+    background: var(--code-bg);
     border-radius: 4px;
     padding: 1px 5px;
     font-size: 12px;
     font-family: "SF Mono", Menlo, monospace;
   }
   pre {
-    background: #f2f2f7;
+    background: var(--code-bg);
     border-radius: 6px;
     padding: 10px 12px;
     font-size: 12px;
     font-family: "SF Mono", Menlo, monospace;
     overflow-x: auto;
   }
-  a { color: #0066cc; }
+  a { color: -apple-system-blue; }
 </style>
 </head>
 <body>

--- a/.github/macos-installer/welcome.html
+++ b/.github/macos-installer/welcome.html
@@ -3,10 +3,17 @@
 <head>
 <meta charset="utf-8"/>
 <style>
+  :root {
+    color-scheme: light dark;
+    --code-bg: rgba(0, 0, 0, 0.07);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --code-bg: rgba(255, 255, 255, 0.12); }
+  }
   body {
     font-family: -apple-system, Helvetica Neue, sans-serif;
     font-size: 13px;
-    color: #1d1d1f;
+    color: -apple-system-label;
     margin: 20px 24px;
     line-height: 1.5;
   }
@@ -15,7 +22,7 @@
   ul { margin: 0 0 10px; padding-left: 20px; }
   li { margin-bottom: 4px; }
   code {
-    background: #f2f2f7;
+    background: var(--code-bg);
     border-radius: 4px;
     padding: 1px 5px;
     font-size: 12px;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,9 @@ jobs:
       - name: Build .pkg installer
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          VER_CLEAN="${VERSION#v}"   # v1.4.1 → 1.4.1
+          VER_CLEAN="${VERSION#v}"   # v1.4.2 → 1.4.2
           ARCH="${{ matrix.arch }}"
           PKG_NAME="deepdiff-db-${VERSION}-darwin-${ARCH}.pkg"
-          DMG_NAME="deepdiff-db-${VERSION}-darwin-${ARCH}.dmg"
 
           # ── 1. Payload: mirrors the install layout on the target volume ──
           #    pkgbuild --install-location / means pkg-payload/ is the root.
@@ -123,8 +122,75 @@ jobs:
             --package-path . \
             "${PKG_NAME}"
 
-          # ── 5. Wrap the .pkg in a DMG for a familiar download experience ─
-          #    Users mount the DMG → double-click the .pkg → wizard launches.
+          echo "PKG_NAME=${PKG_NAME}" >> "$GITHUB_ENV"
+          echo "VERSION=${VERSION}"   >> "$GITHUB_ENV"
+
+      - name: Sign .pkg with Developer ID
+        # Requires secrets: MACOS_CERTIFICATE (base64 .p12), MACOS_CERTIFICATE_PWD,
+        # MACOS_KEYCHAIN_PWD, MACOS_IDENTITY ("Developer ID Installer: Name (TEAMID)").
+        # Skipped gracefully when secrets are not configured.
+        env:
+          MACOS_CERTIFICATE:     ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_KEYCHAIN_PWD:    ${{ secrets.MACOS_KEYCHAIN_PWD }}
+          MACOS_IDENTITY:        ${{ secrets.MACOS_IDENTITY }}
+        run: |
+          if [ -z "${MACOS_CERTIFICATE}" ]; then
+            echo "⚠️  MACOS_CERTIFICATE not set — skipping code signing."
+            echo "    Users will see a Gatekeeper warning on first open."
+            exit 0
+          fi
+
+          # Import the Developer ID Installer certificate into a temporary keychain
+          echo "${MACOS_CERTIFICATE}" | base64 --decode > certificate.p12
+          security create-keychain -p "${MACOS_KEYCHAIN_PWD}" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "${MACOS_KEYCHAIN_PWD}" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import certificate.p12 \
+            -k build.keychain \
+            -P "${MACOS_CERTIFICATE_PWD}" \
+            -T /usr/bin/productsign
+          security set-key-partition-list \
+            -S apple-tool:,apple: -s -k "${MACOS_KEYCHAIN_PWD}" build.keychain
+
+          # Sign the distribution package
+          productsign \
+            --sign "${MACOS_IDENTITY}" \
+            "${PKG_NAME}" \
+            "${PKG_NAME}-signed.pkg"
+          mv "${PKG_NAME}-signed.pkg" "${PKG_NAME}"
+
+          # Clean up keychain and certificate
+          security delete-keychain build.keychain
+          rm -f certificate.p12
+
+      - name: Notarize and staple .pkg
+        # Requires secrets: MACOS_NOTARIZATION_APPLE_ID, MACOS_NOTARIZATION_TEAM_ID,
+        # MACOS_NOTARIZATION_PWD (app-specific password).
+        # Skipped gracefully when secrets are not configured.
+        env:
+          MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
+          MACOS_NOTARIZATION_TEAM_ID:  ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
+          MACOS_NOTARIZATION_PWD:      ${{ secrets.MACOS_NOTARIZATION_PWD }}
+        run: |
+          if [ -z "${MACOS_NOTARIZATION_APPLE_ID}" ]; then
+            echo "⚠️  Notarization secrets not set — skipping notarization."
+            exit 0
+          fi
+
+          xcrun notarytool submit "${PKG_NAME}" \
+            --apple-id  "${MACOS_NOTARIZATION_APPLE_ID}" \
+            --team-id   "${MACOS_NOTARIZATION_TEAM_ID}" \
+            --password  "${MACOS_NOTARIZATION_PWD}" \
+            --wait
+
+          # Staple the notarization ticket so Gatekeeper works offline
+          xcrun stapler staple "${PKG_NAME}"
+
+      - name: Wrap .pkg in DMG
+        run: |
+          DMG_NAME="${PKG_NAME%.pkg}.dmg"
           mkdir -p dmg-stage
           cp "${PKG_NAME}" dmg-stage/
 


### PR DESCRIPTION
## Issues fixed

### 1. Code elements broken in dark mode

`<code>` and `<pre>` blocks used a hardcoded `background: #f2f2f7` (light gray). In dark mode the macOS installer renders this as a visually broken highlight over the text.

**Fix:** replaced with a CSS custom property using `rgba` with opacity so it adapts in both modes:

```css
:root {
  color-scheme: light dark;
  --code-bg: rgba(0, 0, 0, 0.07);
}
@media (prefers-color-scheme: dark) {
  :root { --code-bg: rgba(255, 255, 255, 0.12); }
}
```

Applied to `welcome.html`, `readme.html`, and `conclusion.html`.

### 2. Gatekeeper "unrecognized developer" warning on first open

Unsigned `.pkg` files are blocked by Gatekeeper on macOS. The fix is to sign with a **Developer ID Installer** certificate and notarize with Apple.

The monolithic "Build .pkg installer" step is split into four:

| Step | What it does |
|---|---|
| **Build .pkg installer** | `pkgbuild` + `productbuild`, exports `PKG_NAME` |
| **Sign .pkg with Developer ID** | Imports cert into temp keychain → `productsign` → deletes keychain |
| **Notarize and staple .pkg** | `notarytool submit --wait` → `stapler staple` (works offline) |
| **Wrap .pkg in DMG** | `hdiutil create` → exports `DMG_NAME` |

Both the signing and notarization steps **exit 0 gracefully** when their secrets are absent — builds still succeed without an Apple Developer account, with a warning printed to the log.

## Required GitHub secrets

Set in **Settings → Secrets and variables → Actions**:

| Secret | Value |
|---|---|
| `MACOS_CERTIFICATE` | `base64 -i DevIDInstaller.p12` output |
| `MACOS_CERTIFICATE_PWD` | Password used when exporting the .p12 |
| `MACOS_KEYCHAIN_PWD` | Any string (temporary keychain password) |
| `MACOS_IDENTITY` | `Developer ID Installer: Your Name (TEAMID)` |
| `MACOS_NOTARIZATION_APPLE_ID` | Apple ID email |
| `MACOS_NOTARIZATION_TEAM_ID` | 10-character team ID |
| `MACOS_NOTARIZATION_PWD` | App-specific password from appleid.apple.com |