### PR TITLE
fix(nsis): prefix StrReplaceAll with un. for uninstall section

### DIFF
--- a/.github/windows-installer.nsi
+++ b/.github/windows-installer.nsi
@@ -112,12 +112,12 @@ Section "Uninstall"
   Push "$0"
   Push "$INSTDIR;"
   Push ""
-  Call StrReplaceAll
+  Call un.StrReplaceAll
   Pop $0
   Push "$0"
   Push ";$INSTDIR"
   Push ""
-  Call StrReplaceAll
+  Call un.StrReplaceAll
   Pop $0
   WriteRegExpandStr HKLM \
     "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" \
@@ -162,9 +162,10 @@ Function StrContains
   Push $R0
 FunctionEnd
 
-; ── Helper: StrReplaceAll ────────────────────────────────────────────────────
+; ── Helper: un.StrReplaceAll ─────────────────────────────────────────────────
 ; Stack (top→bottom): [haystack] [find] [replace] → [result]
-Function StrReplaceAll
+; Must be prefixed un. because it is called from the Uninstall section.
+Function un.StrReplaceAll
   Exch $2   ; replace
   Exch
   Exch $1   ; find

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-05-03
+
+### Fixed
+
+- **Windows uninstaller crash — `StrReplaceAll` not found** — NSIS requires functions called from the `Uninstall` section to be defined as `Function un.FunctionName`. `StrReplaceAll` was defined as a plain function, causing `makensis` to abort with "Call must be used with function names starting with 'un.'". Renamed to `un.StrReplaceAll` and updated both call sites. ([#119](https://github.com/iamvirul/deepdiff-db/pull/119))
+
 ## [1.4.3] - 2026-05-03
 
 ### Added
@@ -513,6 +519,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MySQL foreign key check handling
 
 [Unreleased]: https://github.com/iamvirul/deepdiff-db/compare/v1.4.3...HEAD
+[1.4.4]: https://github.com/iamvirul/deepdiff-db/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/iamvirul/deepdiff-db/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/iamvirul/deepdiff-db/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/iamvirul/deepdiff-db/compare/v1.4.0...v1.4.1


### PR DESCRIPTION
## Problem

\`makensis\` aborted with:

\`\`\`
Call must be used with function names starting with "un." in the uninstall section.
Usage: Call function_name | [:label_name]
Error in script "installer.nsi" on line 115 -- aborting creation process
\`\`\`

NSIS enforces that any function called from an \`Uninstall\` section must be defined as \`Function un.FunctionName\` and called as \`Call un.FunctionName\`. \`StrReplaceAll\` was defined as a plain \`Function\` but called from the \`Uninstall\` section.

## Fix

Rename \`Function StrReplaceAll\` → \`Function un.StrReplaceAll\` and update both \`Call\` sites in the uninstall section.

\`StrContains\` is only called from the install section and stays unprefixed.

| Function | Called from | Prefix needed |
|---|---|---|
| \`StrContains\` | Install section | none |
| \`un.StrReplaceAll\` | Uninstall section | \`un.\` ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows uninstaller to properly clean up system PATH entries when removing the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->