### PR TITLE
fix(security): bump Go to 1.25.10 to patch stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.24', '1.25.9']
+        go-version: ['1.24', '1.25.10']
     
     steps:
       - name: Checkout code
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: false
 
       - name: Merge coverage files
-        if: matrix.go-version == '1.25.9'
+        if: matrix.go-version == '1.25.10'
         run: |
           # Merge coverage files using go tool cover
           echo "mode: atomic" > coverage.txt
@@ -52,7 +52,7 @@ jobs:
         continue-on-error: false
 
       - name: Verify coverage file exists
-        if: matrix.go-version == '1.25.9'
+        if: matrix.go-version == '1.25.10'
         run: |
           if [ ! -f coverage.txt ]; then
             echo "Error: coverage.txt not found"
@@ -62,7 +62,7 @@ jobs:
           head -5 coverage.txt
 
       - name: Upload coverage artifact for merging
-        if: matrix.go-version == '1.25.9'
+        if: matrix.go-version == '1.25.10'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-unit-${{ github.run_id }}
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
           cache-dependency-path: go.sum
 
       - name: Verify dependencies
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
           cache-dependency-path: go.sum
 
       - name: Download unit test coverage artifact
@@ -176,7 +176,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
           cache-dependency-path: go.sum
 
       - name: Run linter
@@ -198,7 +198,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
           cache-dependency-path: go.sum
 
       - name: Download dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.5] - 2026-05-19
+
+### Security
+
+- **Bumped Go to 1.25.10** — Resolves 4 Go standard library vulnerabilities reported by `govulncheck`:
+  - **GO-2026-4982** — XSS via meta content URL escape bypass in `html/template`
+  - **GO-2026-4980** — XSS via escaper bypass in `html/template`
+  - **GO-2026-4971** — Panic on NUL byte in `net.Dial` / `net.LookupPort` (Windows)
+  - **GO-2026-4918** — HTTP/2 infinite loop on bad `SETTINGS_MAX_FRAME_SIZE` in `net/http`
+  ([#122](https://github.com/iamvirul/deepdiff-db/pull/122))
+
 ## [1.4.4] - 2026-05-03
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iamvirul/deepdiff-db
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/go-sql-driver/mysql v1.9.3


### PR DESCRIPTION
## Summary

- Bumps Go from `1.25.9` → `1.25.10` in `go.mod` and all CI workflow jobs
- Fixes 4 `govulncheck` findings that were failing the Security Scan on main

## Vulnerabilities Fixed

| ID | Package | Issue |
|----|---------|-------|
| GO-2026-4982 | `html/template` | XSS via meta content URL bypass |
| GO-2026-4980 | `html/template` | XSS via escaper bypass |
| GO-2026-4971 | `net` | Panic on NUL byte in `Dial`/`LookupPort` (Windows) |
| GO-2026-4918 | `net/http` | HTTP/2 infinite loop on bad `SETTINGS_MAX_FRAME_SIZE` |

## Test plan

- [ ] Security Scan CI job passes (`govulncheck ./...` exits 0)
- [ ] All other CI jobs (unit tests, integration tests, lint, build) remain green